### PR TITLE
Enhancement/video id fetch by transmision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
-## [0.2.6] - 2025-04-22
+## [0.2.7] - 2025-04-26
+
+### Changed
+- Now storing channel video if until the end of the live transmission.
+- Cron will not execute fetch for specific channel if that channel has a video id cached.
+
+## [0.2.6] - 2025-04-25
 
 ### Changed
 - Now storing channel video id until end of day, updating it by cron or on-demand
@@ -25,7 +31,7 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Removed
 - Removed video id cache entry by program since it's no longer used
 
-## [0.2.5] - 2025-04-22
+## [0.2.5] - 2025-04-24
 
 ### Changed
 - Now using video id for all the channel's live stream without cuts

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -10,6 +10,7 @@ import { RedisService } from '../redis/redis.service';
 import * as dayjs from 'dayjs';
 import * as utc from 'dayjs/plugin/utc';
 import * as timezone from 'dayjs/plugin/timezone';
+import { getCurrentBlockTTL } from '@/utils/getBlockTTL.util';
 
 interface FindAllOptions {
   page?: number;
@@ -118,8 +119,8 @@ export class SchedulesService {
   
           if (!cachedVideoId) {
             console.warn(`[SchedulesService] No cached channel video ID for program ${program.id}, fetching on-demand...`);
-  
-            const videoId = await this.youtubeLiveService.getLiveVideoId(channelId, 'onDemand');
+            const blockTTL = await getCurrentBlockTTL(channelId, schedules);
+            const videoId = await this.youtubeLiveService.getLiveVideoId(channelId, blockTTL, 'onDemand');
             if (videoId && videoId !== '__SKIPPED__') {
               cachedVideoId = videoId;
             } else if (videoId !== '__SKIPPED__') {

--- a/src/utils/convertTimeToMinutes.util.ts
+++ b/src/utils/convertTimeToMinutes.util.ts
@@ -1,0 +1,4 @@
+export function convertTimeToMinutes(time: string): number {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
+}

--- a/src/utils/getBlockTTL.util.ts
+++ b/src/utils/getBlockTTL.util.ts
@@ -1,0 +1,52 @@
+import { Schedule } from "@/schedules/schedules.entity";
+import * as dayjs from 'dayjs';
+import * as utc from 'dayjs/plugin/utc';
+import * as timezone from 'dayjs/plugin/timezone';
+import { convertTimeToMinutes } from "./convertTimeToMinutes.util";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+export function getEndOfDayTTL(): number {
+    const now = dayjs().tz('America/Argentina/Buenos_Aires');
+    return now.endOf('day').diff(now, 'second');
+  }
+
+export async function getCurrentBlockTTL(channelId: string, schedules: Schedule[]): Promise<number> {
+    const now = dayjs().tz('America/Argentina/Buenos_Aires');
+    // Filtrar sólo del canal
+    const channelSched = schedules
+      .filter(s => s.program.channel?.youtube_channel_id === channelId)
+      .map(s => ({
+        start: convertTimeToMinutes(s.start_time),
+        end: convertTimeToMinutes(s.end_time),
+      }))
+      .sort((a, b) => a.start - b.start);
+
+    // Detectar el bloque que contiene el minuto actual (gap <2 min)
+    let blockEnd: number | null = null;
+    let prevEnd: number | null = null;
+    for (const seg of channelSched) {
+      if (seg.start <= now.hour() * 60 + now.minute() && seg.end > now.hour() * 60 + now.minute()) {
+        // incia bloque con este segmento
+        prevEnd = seg.end;
+        blockEnd = seg.end;
+        continue;
+      }
+      if (prevEnd !== null && seg.start - prevEnd < 2) {
+        // extiende bloque
+        blockEnd = seg.end;
+        prevEnd = seg.end;
+        continue;
+      }
+      // si bloque ya detectado y sin extender, salimos
+      if (blockEnd !== null) break;
+    }
+    if (!blockEnd) {
+      // fallback: hasta fin del día
+      return getEndOfDayTTL();
+    }
+    // calcular segundos hasta blockEnd
+    const endMoment = now.startOf('day').add(blockEnd, 'minute');
+    return endMoment.diff(now, 'second');
+}

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -54,10 +54,12 @@ export class YoutubeLiveService {
     // 2) Verifico si sigue público
     const isPrivate = await this.isPrivateVideo(videoId);
     if (!isPrivate) {
+      console.log(`🔁 Skipping fetch for ${channelId}, already cached until block end and it's public`);
       // sigue bueno, lo devuelvo
       return videoId;
     }
     // si está privado, lo borro de cache
+    console.log(`🔁 Deleting cached videoId for ${channelId} because it's private`);
     await this.redisService.del(`liveVideoIdByChannel:${channelId}`);
   }
 

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -50,6 +50,7 @@ export class YoutubeLiveService {
       const videoId = response.data.items?.[0]?.id?.videoId || null;
 
       if (!videoId) {
+        console.log(`🚫 No live video ID found for channel ${channelId} by ${context}`);
         await this.redisService.set(notFoundKey, '1', 900);
         return null;
       }

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -62,6 +62,8 @@ export class YoutubeLiveService {
         console.log(`📌 Stored first live video ID for channel ${channelId}: ${videoId} by ${context}`);
       } else if (cached !== videoId) {
         console.log(`🔁 Channel ${channelId} changed video ID from ${cached} to ${videoId} by ${context}`);
+      } else if (cached === videoId) {
+        console.log(`🔁 Channel ${channelId} has the same video ID ${videoId} by ${context}`);
       }
       await this.redisService.set(liveVideoKey, videoId, 86400);
       console.log(`📌 Stored current live video ID for channel ${channelId}: ${videoId} by ${context}`);


### PR DESCRIPTION
## 📝 Descripción

Se agrega consulta a youtube por el estado del video id guardado, que solo consume 1 unidad. Si el video sigue estando vigente y público, skippeamos el fetch a youtube que consume 100 unidaes. Si el video está privado o ya no es válido, lo borramos de la caché y disparamos el fetch de 100 unidades.

## 🔍 Tipo de cambio

- [ ] Feature nueva
- [X] Mejora existente
- [ ] Fix de bug
- [ ] Otro