### PR TITLE
⚡ Bolt: [performance improvement] Replace N+1 Redis GET queries with single MGET in getLiveStatuses

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-03-05 - [N+1 DB Query Avoidance in Scraper]
 **Learning:** Found N+1 query patterns inside the `insertSchedule` method of `ScraperService`. For every scraped item, it runs `await this.programRepo.find` and then for each day `await this.scheduleRepo.findOne`. This leads to poor performance.
 **Action:** Always pre-fetch existing records into a Map or Dictionary outside of the loops to avoid N+1 DB calls.
+
+## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
+**Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
+**Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.24.6] - 2026-03-24
+
+### Changed
+- Streamer live status optimization
+
 ## [1.24.5] - 2026-03-23
 
 ### Added

--- a/src/streamers/streamer-live-status.service.spec.ts
+++ b/src/streamers/streamer-live-status.service.spec.ts
@@ -14,6 +14,7 @@ describe('StreamerLiveStatusService', () => {
     get: jest.fn(),
     set: jest.fn(),
     del: jest.fn(),
+    mget: jest.fn(),
   };
 
   const mockConfigService = {
@@ -207,9 +208,7 @@ describe('StreamerLiveStatusService', () => {
         ttl: 604800,
       };
 
-      mockRedisService.get
-        .mockResolvedValueOnce(cache1)
-        .mockResolvedValueOnce(cache2);
+      mockRedisService.mget.mockResolvedValueOnce([cache1, cache2]);
 
       const result = await service.getLiveStatuses([1, 2]);
 

--- a/src/streamers/streamer-live-status.service.ts
+++ b/src/streamers/streamer-live-status.service.ts
@@ -121,15 +121,20 @@ export class StreamerLiveStatusService {
   async getLiveStatuses(streamerIds: number[]): Promise<Map<number, StreamerLiveStatusCache>> {
     const result = new Map<number, StreamerLiveStatusCache>();
 
-    // Fetch all in parallel
-    const promises = streamerIds.map(async (id) => {
-      const status = await this.getLiveStatus(id);
+    if (streamerIds.length === 0) {
+      return result;
+    }
+
+    // ⚡ Bolt Optimization: Replace N+1 Redis queries with a single mget
+    const keys = streamerIds.map(id => `${this.CACHE_PREFIX}${id}`);
+    const statuses = await this.redisService.mget<StreamerLiveStatusCache>(keys);
+
+    statuses.forEach((status, index) => {
       if (status) {
-        result.set(id, status);
+        result.set(streamerIds[index], status);
       }
     });
 
-    await Promise.all(promises);
     return result;
   }
 


### PR DESCRIPTION
💡 **What:** Replaced individual Redis `GET` calls with a single bulk `MGET` call when fetching live statuses for multiple streamers in `StreamerLiveStatusService.getLiveStatuses`.

🎯 **Why:** To eliminate the N+1 Redis query anti-pattern. Instead of iterating over `streamerIds` and concurrently calling `redisService.get` (wrapped in `Promise.all`), a single round-trip `redisService.mget` call securely retrieves the statuses for all the requested keys in bulk. This drastically reduces the network overhead and connection latency.

📊 **Impact:** Reduces network requests to Redis from $O(n)$ to $O(1)$. Noticeable performance improvement and latency reduction when processing large payloads or frequent API requests on live streams.

🔬 **Measurement:** Verify the changes using the provided unit tests in `src/streamers/streamer-live-status.service.spec.ts` which mock `mget`. Run `npm run test -- src/streamers/streamer-live-status.service.spec.ts`.

---
*PR created automatically by Jules for task [11194336738494325181](https://jules.google.com/task/11194336738494325181) started by @matiasrozenblum*