### PR TITLE
perf: replace N+1 Redis GET with batched MGET in WebhookSubscriptionService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,17 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Added
 
 ### Changed
-- Replaced N+1 Redis GET calls with batched MGET in `getSubscriptionsForStreamer` and `renewExpiredKickSubscriptions`
 
 ### Removed
 
 ### Fixed
 
 ---
+
+## [1.24.6] - 2026-03-28
+
+### Changed
+- Replaced N+1 Redis GET calls with batched MGET in `getSubscriptionsForStreamer` and `renewExpiredKickSubscriptions`
 
 ## [1.24.5] - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Added
 
 ### Changed
+- Replaced N+1 Redis GET calls with batched MGET in `getSubscriptionsForStreamer` and `renewExpiredKickSubscriptions`
 
 ### Removed
 

--- a/src/webhooks/webhook-subscription.service.spec.ts
+++ b/src/webhooks/webhook-subscription.service.spec.ts
@@ -19,6 +19,7 @@ describe('WebhookSubscriptionService', () => {
 
   const mockRedisService = {
     get: jest.fn(),
+    mget: jest.fn(),
     set: jest.fn(),
     del: jest.fn(),
   };
@@ -272,13 +273,19 @@ describe('WebhookSubscriptionService', () => {
         { service: 'kick', url: 'https://kick.com/kickuser', username: 'kickuser' },
       ];
 
-      mockRedisService.get
-        .mockResolvedValueOnce({ subscriptionId: 'sub-online-123' })
-        .mockResolvedValueOnce({ subscriptionId: 'sub-offline-456' })
-        .mockResolvedValueOnce({ subscriptionId: 'kick-sub-789' });
+      mockRedisService.mget.mockResolvedValueOnce([
+        { subscriptionId: 'sub-online-123' },
+        { subscriptionId: 'sub-offline-456' },
+        { subscriptionId: 'kick-sub-789' },
+      ]);
 
       const result = await service.getSubscriptionsForStreamer(1, services);
 
+      expect(mockRedisService.mget).toHaveBeenCalledWith([
+        'webhook:subscription:twitch:testuser:stream.online',
+        'webhook:subscription:twitch:testuser:stream.offline',
+        'webhook:subscription:kick:kickuser',
+      ]);
       expect(result.twitch).toContain('sub-online-123');
       expect(result.twitch).toContain('sub-offline-456');
       expect(result.kick).toContain('kick-sub-789');

--- a/src/webhooks/webhook-subscription.service.ts
+++ b/src/webhooks/webhook-subscription.service.ts
@@ -427,24 +427,40 @@ export class WebhookSubscriptionService {
       kick: [] as string[],
     };
 
+    const keysToFetch: string[] = [];
+    const keyMap: Array<{ key: string; type: 'twitch' | 'kick'; username: string }> = [];
+
     for (const service of services) {
       if (service.service === 'twitch') {
         const username = service.username || this.extractTwitchUsername(service.url);
         if (username) {
-          // Check for both online and offline subscriptions
           const onlineKey = `${this.SUBSCRIPTION_PREFIX}twitch:${username}:stream.online`;
           const offlineKey = `${this.SUBSCRIPTION_PREFIX}twitch:${username}:stream.offline`;
-          const onlineSub = await this.redisService.get(onlineKey);
-          const offlineSub = await this.redisService.get(offlineKey);
-          if (onlineSub) subscriptions.twitch.push((onlineSub as any).subscriptionId);
-          if (offlineSub) subscriptions.twitch.push((offlineSub as any).subscriptionId);
+          keysToFetch.push(onlineKey, offlineKey);
+          keyMap.push({ key: onlineKey, type: 'twitch', username });
+          keyMap.push({ key: offlineKey, type: 'twitch', username });
         }
       } else if (service.service === 'kick') {
         const username = service.username || this.extractKickUsername(service.url);
         if (username) {
           const key = `${this.SUBSCRIPTION_PREFIX}kick:${username}`;
-          const sub = await this.redisService.get(key);
-          if (sub) subscriptions.kick.push((sub as any).subscriptionId || username);
+          keysToFetch.push(key);
+          keyMap.push({ key, type: 'kick', username });
+        }
+      }
+    }
+
+    if (keysToFetch.length > 0) {
+      const results = await this.redisService.mget<any>(keysToFetch);
+      for (let i = 0; i < results.length; i++) {
+        const sub = results[i];
+        if (sub) {
+          const { type, username } = keyMap[i];
+          if (type === 'twitch') {
+            subscriptions.twitch.push(sub.subscriptionId);
+          } else if (type === 'kick') {
+            subscriptions.kick.push(sub.subscriptionId || username);
+          }
         }
       }
     }
@@ -569,13 +585,17 @@ export class WebhookSubscriptionService {
       let active = 0;
       let failed = 0;
 
-      for (const key of keys) {
+      // Batch fetch all stored subscription data in a single Redis call
+      const storedDataBatch = await this.redisService.mget<any>(keys);
+
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
         try {
           // Extract username from key: webhook:subscription:kick:username
           const username = key.replace(`${this.SUBSCRIPTION_PREFIX}kick:`, '');
 
-          // Get stored data
-          const storedData = await this.redisService.get(key) as any;
+          // Get stored data from batch
+          const storedData = storedDataBatch[i] as any;
           const userId = storedData?.userId;
 
           if (!userId) {


### PR DESCRIPTION
## Summary

- **`getSubscriptionsForStreamer`**: previously made 2–3 sequential `redisService.get()` calls (one per Twitch online/offline key + one per Kick key). Now collects all keys first and does a single `redisService.mget()` call — O(N) round-trips → O(1).
- **`renewExpiredKickSubscriptions`** (cron, runs every 4h): previously fetched each Kick subscription's stored data with an individual `get` inside the loop. Now batch-fetches all data before the loop with a single `mget`.
- Spec updated to mock and assert `mget` correctly.

## Context

This unifies and cleans up 3 Jules PRs (#301, #302, #303) that all targeted the same issue. Those PRs were unusable as-is: each contained 200+ unrelated Prettier/ESLint formatting changes across the entire codebase. This PR contains only the meaningful functional change (3 files, 42 additions).

## Risks

**Low.** `mget` returns values in the same order as the input keys array, which is exactly how the new code consumes them. `null` values for missing keys are handled (only non-null entries are pushed to results). No schema or migration changes.

## Test plan
- [x] `npm test src/webhooks/webhook-subscription.service.spec.ts` — all 10 tests pass
- [ ] Verify in staging that streamer live-status lookups and the 4h Kick renewal cron behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)