### PR TITLE
⚡ Bolt: [performance improvement] Replace N+1 Redis queries with mget in getAllLiveStatuses

### DIFF
--- a/src/streamers/streamer-live-status.service.spec.ts
+++ b/src/streamers/streamer-live-status.service.spec.ts
@@ -15,6 +15,9 @@ describe('StreamerLiveStatusService', () => {
     set: jest.fn(),
     del: jest.fn(),
     mget: jest.fn(),
+    client: {
+      scan: jest.fn(),
+    },
   };
 
   const mockConfigService = {
@@ -215,6 +218,45 @@ describe('StreamerLiveStatusService', () => {
       expect(result.size).toBe(2);
       expect(result.get(1)).toEqual(cache1);
       expect(result.get(2)).toEqual(cache2);
+    });
+  });
+
+  describe('getAllLiveStatuses', () => {
+    it('should use mget to avoid N+1 query patterns', async () => {
+      // Mock scan to return 2 keys on first call, then 0 to stop
+      mockRedisService.client.scan.mockResolvedValueOnce([
+        '0',
+        ['streamer_live:1', 'streamer_live:2'],
+      ]);
+
+      const cache1: StreamerLiveStatusCache = {
+        streamerId: 1,
+        isLive: true,
+        services: [],
+        lastUpdated: Date.now(),
+        ttl: 604800,
+      };
+
+      const cache2: StreamerLiveStatusCache = {
+        streamerId: 2,
+        isLive: false, // This one is not live
+        services: [],
+        lastUpdated: Date.now(),
+        ttl: 604800,
+      };
+
+      mockRedisService.mget.mockResolvedValueOnce([cache1, cache2]);
+
+      const result = await service.getAllLiveStatuses();
+
+      expect(mockRedisService.client.scan).toHaveBeenCalled();
+      expect(mockRedisService.mget).toHaveBeenCalledWith([
+        'streamer_live:1',
+        'streamer_live:2',
+      ]);
+      expect(result.size).toBe(1);
+      expect(result.get(1)).toBe(true);
+      expect(result.has(2)).toBe(false);
     });
   });
 

--- a/src/streamers/streamer-live-status.service.ts
+++ b/src/streamers/streamer-live-status.service.ts
@@ -153,13 +153,14 @@ export class StreamerLiveStatusService {
       const keys = reply[1];
 
       if (keys.length > 0) {
-        // Fetch values for these keys
-        for (const key of keys) {
-          const data = await this.redisService.get<StreamerLiveStatusCache>(key);
+        // Fetch values for these keys using mget to avoid N+1 queries
+        const statuses =
+          await this.redisService.mget<StreamerLiveStatusCache>(keys);
+        statuses.forEach((data) => {
           if (data && data.isLive) {
             result.set(data.streamerId, true);
           }
-        }
+        });
       }
     } while (cursor !== '0');
 


### PR DESCRIPTION
💡 What: Refactored `getAllLiveStatuses` in `src/streamers/streamer-live-status.service.ts` to fetch multiple statuses from Redis in a single query using `mget` rather than fetching them one by one inside a loop. Added a test case confirming this behavior in the specs.

🎯 Why: To solve an N+1 query issue. Iterating over keys matched by `scan` and fetching each using an individual `get` was creating multiple sequential roundtrips to Redis, adding unnecessary overhead.

📊 Impact: Reduces network latency to Redis dramatically when fetching all live statuses, significantly improving performance when `getAllLiveStatuses` is invoked.

🔬 Measurement: Verifiable by executing unit tests and by monitoring network timing in environments when `getAllLiveStatuses` evaluates a large set of Streamer Live Status Keys.

---
*PR created automatically by Jules for task [1616806009897551811](https://jules.google.com/task/1616806009897551811) started by @matiasrozenblum*