### PR TITLE
⚡ Bolt: [performance improvement] Batch Redis deletions to reduce network overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-04-04 - [N+1 Redis Network Avoidance in Cache Invalidation]
+**Learning:** Found N+1 Redis command patterns when clearing multiple cache keys consecutively using `await this.redisService.del(key)` inside try-catch blocks or `Promise.all`. These parallel or sequential independent `del` commands introduce unnecessary network round-trips overhead.
+**Action:** Extend `RedisService.del` to accept an array of keys and use `await this.client.del(...keys)` to batch them in a single round-trip, preventing N+1 anti-pattern on deletion as well as reducing await statements overhead.

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -192,9 +192,17 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       // Assert
       expect(youtubeDiscoveryService.getChannelIdFromHandle).toHaveBeenCalledWith('@newhandle');
       // Should invalidate old handle cache when handle changes
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@oldhandle');
+      expect(redisService.del).toHaveBeenCalledWith([
+        'liveStatusByHandle:@oldhandle',
+        'videoIdNotFound:@oldhandle',
+        'notFoundAttempts:@oldhandle'
+      ]);
       // Should also invalidate new handle cache when YouTube channel ID changes (wrong channel ID was cached)
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@newhandle');
+      expect(redisService.del).toHaveBeenCalledWith([
+        'liveStatusByHandle:@newhandle',
+        'videoIdNotFound:@newhandle',
+        'notFoundAttempts:@newhandle'
+      ]);
     });
 
     it('should not invalidate live status caches when handle does not change', async () => {
@@ -238,7 +246,11 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       // Assert
       expect(youtubeDiscoveryService.getChannelIdFromHandle).toHaveBeenCalledWith('@newhandle');
       // Should still invalidate old handle cache even if new channel ID resolution fails
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@oldhandle');
+      expect(redisService.del).toHaveBeenCalledWith([
+        'liveStatusByHandle:@oldhandle',
+        'videoIdNotFound:@oldhandle',
+        'notFoundAttempts:@oldhandle'
+      ]);
       // Note: New handle cache won't be invalidated if channel ID resolution fails (no new channel ID to compare)
     });
 
@@ -312,10 +324,11 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       const result = await service.clearChannelCache(handle);
 
       // Assert
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@testhandle');
-      expect(redisService.del).toHaveBeenCalledWith('videoIdNotFound:@testhandle');
-      expect(redisService.del).toHaveBeenCalledWith('notFoundAttempts:@testhandle');
-      expect(redisService.del).toHaveBeenCalledTimes(3);
+      expect(redisService.del).toHaveBeenCalledWith([
+        'liveStatusByHandle:@testhandle',
+        'videoIdNotFound:@testhandle',
+        'notFoundAttempts:@testhandle'
+      ]);
       expect(result.cleared).toEqual(['liveStatusByHandle', 'videoIdNotFound', 'notFoundAttempts']);
     });
 

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -148,8 +148,10 @@ export class ChannelsService {
   
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del([
+        'schedules:week:complete',
+        'channels:visible_with_categories'
+      ]);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -219,8 +221,10 @@ export class ChannelsService {
 
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del([
+        'schedules:week:complete',
+        'channels:visible_with_categories'
+      ]);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -319,8 +323,10 @@ export class ChannelsService {
     
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del([
+        'schedules:week:complete',
+        'channels:visible_with_categories'
+      ]);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -347,8 +353,10 @@ export class ChannelsService {
     
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del([
+        'schedules:week:complete',
+        'channels:visible_with_categories'
+      ]);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -664,9 +672,11 @@ export class ChannelsService {
     try {
       // Invalidate unified cache and related keys
       // Note: liveStreamsByChannel no longer exists (unified into liveStatusByHandle)
-      await this.redisService.del(`liveStatusByHandle:${handle}`);
-      await this.redisService.del(`videoIdNotFound:${handle}`);
-      await this.redisService.del(`notFoundAttempts:${handle}`);
+      await this.redisService.del([
+        `liveStatusByHandle:${handle}`,
+        `videoIdNotFound:${handle}`,
+        `notFoundAttempts:${handle}`
+      ]);
       console.log(`🗑️ Invalidated cache keys for: ${handle}`);
     } catch (error) {
       console.error(`❌ Error invalidating live status cache for ${handle}:`, error.message);
@@ -686,14 +696,12 @@ export class ChannelsService {
     
     try {
       // Clear all channel-related cache entries
-      await this.redisService.del(`liveStatusByHandle:${handle}`);
-      cleared.push('liveStatusByHandle');
-      
-      await this.redisService.del(`videoIdNotFound:${handle}`);
-      cleared.push('videoIdNotFound');
-      
-      await this.redisService.del(`notFoundAttempts:${handle}`);
-      cleared.push('notFoundAttempts');
+      await this.redisService.del([
+        `liveStatusByHandle:${handle}`,
+        `videoIdNotFound:${handle}`,
+        `notFoundAttempts:${handle}`
+      ]);
+      cleared.push('liveStatusByHandle', 'videoIdNotFound', 'notFoundAttempts');
       
       console.log(`🗑️ Manually cleared cache keys for: ${handle}`);
       return { cleared };

--- a/src/panelists/panelists.service.ts
+++ b/src/panelists/panelists.service.ts
@@ -110,10 +110,10 @@ export class PanelistsService {
     Object.assign(panelist, updatePanelistDto);
     const updatedPanelist = await this.panelistsRepository.save(panelist);
     
-    await Promise.all([
-      this.redisService.del('panelists:all'),
-      this.redisService.del(`panelists:${id}`),
-      this.redisService.del('schedules:week:complete'), // Clear unified schedule cache since panelist info appears in schedules
+    await this.redisService.del([
+      'panelists:all',
+      `panelists:${id}`,
+      'schedules:week:complete', // Clear unified schedule cache since panelist info appears in schedules
     ]);
     
     // Warm cache asynchronously (non-blocking)
@@ -134,9 +134,9 @@ export class PanelistsService {
   async remove(id: string): Promise<boolean> {
     const result = await this.panelistsRepository.delete(id);
     if ((result?.affected ?? 0) > 0) {
-      await Promise.all([
-        this.redisService.del('panelists:all'),
-        this.redisService.del(`panelists:${id}`),
+      await this.redisService.del([
+        'panelists:all',
+        `panelists:${id}`,
       ]);
       // Notify and revalidate
       await this.notifyUtil.notifyAndRevalidate({
@@ -169,8 +169,10 @@ export class PanelistsService {
       panelist.programs.push(program);
       await this.panelistsRepository.save(panelist);
       console.log(`[Cache] Invalidating cache for panelist ${panelistId} after adding to program ${programId}`);
-      await this.redisService.del(`panelists:${panelistId}`);
-      await this.redisService.del('schedules:week:complete');
+      await this.redisService.del([
+        `panelists:${panelistId}`,
+        'schedules:week:complete'
+      ]);
       
       // Warm cache asynchronously (non-blocking)
       this.schedulesService.debouncedWarmSchedulesCache();
@@ -193,8 +195,10 @@ export class PanelistsService {
       panelist.programs = panelist.programs.filter(p => p.id !== Number(programId));
       await this.panelistsRepository.save(panelist);
       console.log(`[Cache] Invalidating cache for panelist ${panelistId} after removing from program ${programId}`);
-      await this.redisService.del(`panelists:${panelistId}`);
-      await this.redisService.del('schedules:week:complete');
+      await this.redisService.del([
+        `panelists:${panelistId}`,
+        'schedules:week:complete'
+      ]);
       
       // Warm cache asynchronously (non-blocking)
       this.schedulesService.debouncedWarmSchedulesCache();

--- a/src/redis/redis.service.spec.ts
+++ b/src/redis/redis.service.spec.ts
@@ -71,6 +71,16 @@ describe('RedisService', () => {
       await service.del('key');
       expect(mockClient.del).toHaveBeenCalledWith('key');
     });
+
+    it('deletes multiple keys when array is provided', async () => {
+      await service.del(['key1', 'key2']);
+      expect(mockClient.del).toHaveBeenCalledWith('key1', 'key2');
+    });
+
+    it('does nothing when empty array is provided', async () => {
+      await service.del([]);
+      expect(mockClient.del).not.toHaveBeenCalled();
+    });
   });
 
   describe('incr', () => {

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -74,8 +74,13 @@ export class RedisService implements OnModuleInit {
     return values.map(v => (v ? JSON.parse(v) : null));
   }
 
-  async del(key: string): Promise<void> {
-    await this.client.del(key);
+  async del(key: string | string[]): Promise<void> {
+    if (Array.isArray(key)) {
+      if (key.length === 0) return;
+      await this.client.del(...key);
+    } else {
+      await this.client.del(key);
+    }
   }
 
   async incr(key: string): Promise<number> {

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -372,8 +372,10 @@ describe('WeeklyOverridesService', () => {
       const result = await service.deleteWeeklyOverride(overrideId);
 
       expect(result).toBe(true);
-      expect(redisService.del).toHaveBeenCalledWith(`weekly_override:${overrideId}`);
-      expect(redisService.del).toHaveBeenCalledWith('schedules:week:complete');
+      expect(redisService.del).toHaveBeenCalledWith([
+        `weekly_override:${overrideId}`,
+        'schedules:week:complete'
+      ]);
     });
 
     it('should return false when override does not exist', async () => {

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -666,8 +666,10 @@ export class WeeklyOverridesService {
       return false;
     }
 
-    await this.redisService.del(`weekly_override:${overrideId}`);
-    await this.redisService.del('schedules:week:complete');
+    await this.redisService.del([
+      `weekly_override:${overrideId}`,
+      'schedules:week:complete'
+    ]);
     
     // Smart weekly cache update: update instead of invalidate
     await this.updateWeeklyCacheForWeek(exists.weekStartDate);

--- a/src/youtube/youtube-live.service.spec.ts
+++ b/src/youtube/youtube-live.service.spec.ts
@@ -140,8 +140,10 @@ describe('YoutubeLiveService', () => {
         streamCount: 1
       }), 100);
       // Should clear both not-found keys when video is found
-      expect(redisService.del).toHaveBeenCalledWith('videoIdNotFound:handle');
-      expect(redisService.del).toHaveBeenCalledWith('notFoundAttempts:handle');
+      expect(redisService.del).toHaveBeenCalledWith([
+        'videoIdNotFound:handle',
+        'notFoundAttempts:handle'
+      ]);
       expect(result).toBe('vid123');
     });
 

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -198,8 +198,10 @@ export class YoutubeLiveService {
       await this.redisService.set(statusCacheKey, cacheData, cacheData.ttl);
 
       // Clear the "not-found" flag and attempt tracking since we found live streams
-      await this.redisService.del(notFoundKey);
-      await this.redisService.del(`notFoundAttempts:${handle}`);
+      await this.redisService.del([
+        notFoundKey,
+        `notFoundAttempts:${handle}`
+      ]);
       this.logger.debug(`📌 Cached ${handle} → ${videoId} (TTL ${blockTTL}s)`);
 
       // Notify clients about the new video ID


### PR DESCRIPTION
💡 **What**: Refactored `RedisService.del` to accept an array of strings, enabling it to map into `this.client.del(...key)`. Replaced several occurrences of multiple sequential `redisService.del()` (as well as inside `Promise.all()`) across the application to pass an array of keys instead.

🎯 **Why**: When clearing multiple related cache keys (e.g. `panelist`, `unified cache` and `schedules:week:complete`), the application was issuing individual `DEL` commands, resulting in an "N+1" network overhead pattern and multiple await allocations.

📊 **Impact**: Reduces Redis network roundtrips for cache invalidation operations, leading to faster completion times and less CPU overhead from promise allocations during bulk invalidations.

🔬 **Measurement**: Observe latency when invalidating channel, program or panelist caches; Redis commands monitoring via ioredis debug logs will show a single `DEL` command being passed with multiple arguments rather than N distinct sequential commands.

---
*PR created automatically by Jules for task [3564612924326797993](https://jules.google.com/task/3564612924326797993) started by @matiasrozenblum*