### PR TITLE
Release 1.24.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Removed
 
 ### Fixed
+
+---
+
+## [1.24.9] - 2026-04-08
+
+### Fixed
 - Channels with invisible overlapping schedules are no longer incorrectly skipped during YouTube live fetch. The current-program lookup now excludes invisible programs so a visible concurrent program is correctly used.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Removed
 
 ### Fixed
+- Channels with invisible overlapping schedules are no longer incorrectly skipped during YouTube live fetch. The current-program lookup now excludes invisible programs so a visible concurrent program is correctly used.
 
 ---
 

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -636,6 +636,7 @@ export class YoutubeLiveService {
       const currentProgram = schedules.find(s => {
         const chId = s.program?.channel?.youtube_channel_id;
         if (chId !== channelId) return false;
+        if (s.program?.is_visible === false) return false; // Skip invisible programs
         const startNum = this.convertTimeToMinutes(s.start_time);
         const endNum = this.convertTimeToMinutes(s.end_time);
         return currentTimeInMinutes >= startNum && currentTimeInMinutes < endNum;
@@ -643,11 +644,6 @@ export class YoutubeLiveService {
 
       if (currentProgram?.program) {
         currentProgramName = currentProgram.program.name; // Capture name for sorting logic
-
-        if (currentProgram.program.is_visible === false) {
-          this.logger.debug(`🚫 Skipping ${handle} (${channelId}) - current program marked as not visible`);
-          return '__SKIPPED__';
-        }
       }
     } catch (visErr) {
       // Non-fatal: if visibility check fails, proceed as before


### PR DESCRIPTION
## [1.24.9] - 2026-04-08

### Fixed
- Channels with invisible overlapping schedules are no longer incorrectly skipped during YouTube live fetch. The current-program lookup now excludes invisible programs so a visible concurrent program is correctly used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)