### PR TITLE
Release 1.24.10

### DIFF
--- a/.claude/commands/sync-db.md
+++ b/.claude/commands/sync-db.md
@@ -1,0 +1,35 @@
+Replicate production database content into staging.
+
+## Context
+This syncs content tables (channels, programs, schedules, streamers, banners, etc.) from production to staging Supabase databases. User data (users, devices, subscriptions) is NOT touched.
+
+## Steps
+
+### 1. Check prerequisites
+- Verify `pg_dump` and `psql` are installed: `which pg_dump psql`
+- If not found, tell the user to install: `brew install postgresql`
+
+### 2. Check for connection strings
+- Check if `.env.sync` exists in the repo root with `PROD_DATABASE_URL` and `STAGING_DATABASE_URL`.
+- If not, ask the user to create it:
+  ```
+  # .env.sync (gitignored - never commit this)
+  PROD_DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+  STAGING_DATABASE_URL=postgresql://postgres.[project-ref]:[password]@aws-0-[region].pooler.supabase.com:6543/postgres
+  ```
+- The connection strings are in Supabase Dashboard → Settings → Database → Connection string (URI).
+- Use the "Transaction pooler" connection string (port 6543).
+
+### 3. Explain what will happen
+Tell the user:
+- **Will be synced**: channels, programs, schedules, categories, streamers, panelists, banners, config (and junction tables)
+- **Will NOT be synced**: users, devices, subscriptions, push tokens
+- **Side effect**: Staging subscriptions (program + streamer) will be deleted because they reference content IDs that get replaced. Users are preserved.
+
+### 4. Execute the sync
+- Run: `bash scripts/sync-prod-to-staging.sh`
+- Show the output (row counts) to the user.
+
+### 5. Report
+- Show the verification table with row counts.
+- Remind: staging subscriptions were cleared, users are intact.

--- a/.claude/commands/task.md
+++ b/.claude/commands/task.md
@@ -1,0 +1,134 @@
+You are a senior backend engineer for La Guia del Streaming (NestJS 11 + TypeORM + PostgreSQL).
+
+## Task: $ARGUMENTS
+
+---
+
+## Phase 1: Analysis
+
+Spawn an Explore subagent to investigate:
+- Which modules, services, controllers, entities are affected
+- Existing patterns and conventions to follow
+- Whether database migrations are needed
+- Whether this affects API contracts consumed by frontend or mobile
+
+---
+
+## Phase 2: Plan
+
+Present the following to the user and wait for explicit approval before proceeding:
+
+- **Branch type**: `feature/` (new functionality) | `fix/` (bug fix) | `enhancement/` (improvement)
+- **Branch name**: descriptive kebab-case (e.g. `fix/schedules-visible-filter`)
+- **Changes**: list of files to create/modify with a one-line description each
+- **Migrations**: yes/no — what schema changes are needed
+- **Cross-repo impact**: any endpoints or DTOs that affect frontend or mobile consumers
+- **Risk**: low / medium / high
+
+⚠️ Do NOT proceed past this point until the user explicitly approves the plan.
+
+---
+
+## Phase 3: Implementation
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b <branch-name>
+```
+
+Follow NestJS conventions:
+- DTOs with `class-validator` decorators on all inputs
+- Services as `@Injectable()` with proper DI
+- Controllers with `@ApiTags`, `@ApiOperation` Swagger decorators
+- TypeORM entities with proper relations and column types
+- `dayjs` for all date handling (timezone: `America/Argentina/Buenos_Aires`)
+- NestJS built-in exceptions (`NotFoundException`, `BadRequestException`, etc.)
+- Guard sensitive endpoints with `@UseGuards(JwtAuthGuard)`
+
+If any entity changed:
+```bash
+npm run migration:generate -- src/migrations/DescriptiveName
+```
+
+---
+
+## Phase 4: Review
+
+Inline review of all changes:
+- **Correctness**: query logic, edge cases, race conditions, migration reversibility
+- **Security**: auth guards on protected endpoints, input validation, no raw SQL with user input, no secrets in code
+- **Performance**: N+1 queries, missing indexes, Redis batching opportunities
+- **API design**: REST conventions, Swagger docs updated, backward compatibility
+- **Code quality**: no `any`, no unused imports, proper TypeScript types
+
+Fix all BLOCKER and WARNING issues found. List SUGGESTIONs to the user without applying them.
+
+---
+
+## Phase 5: Validate
+
+Run in order, fix any issues before proceeding:
+1. `npm run lint`
+2. `npm run build`
+3. `npm test`
+
+If new functionality was added without tests, flag it explicitly to the user.
+
+---
+
+## Phase 6: Changelog
+
+- Read `CHANGELOG.md`
+- Add entry under the appropriate section (Added / Changed / Fixed)
+- Commit: `git commit -m "chore: update CHANGELOG for <branch-name>"`
+
+---
+
+## Phase 7: Staging deploy
+
+```bash
+git push origin <branch-name>
+git checkout staging && git pull origin staging
+git merge -X theirs <branch-name>
+git push origin staging
+git checkout <branch-name>
+```
+
+---
+
+## Phase 8: Feedback loop
+
+Report to the user:
+- Bullet summary of what was implemented
+- Staging URL: `https://streaming-guide-backend-staging.up.railway.app`
+- Cross-repo impacts (if any) — what frontend/mobile may need to update
+- "Ready to test. Let me know what you find."
+
+Wait for user feedback.
+
+**If issues reported**: understand the problem, fix it (return to Phase 3 for that specific issue), re-validate, re-deploy, report again.
+
+**When user confirms OK**: proceed to Phase 9.
+
+---
+
+## Phase 9: Merge to develop
+
+```bash
+git checkout develop && git pull origin develop
+git merge <branch-name>
+git push origin develop
+```
+
+Ask: "Do you want to create a release now?"
+- If yes: follow the `/release` workflow
+- If no: confirm the branch is merged and ready for the next release
+
+---
+
+## Hard rules
+- Never skip the plan checkpoint (Phase 2)
+- Never force-push
+- Never modify entity schemas without generating a migration
+- Always flag cross-repo impacts before deploying
+- Read files before editing them

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ backend-firebase-key.json
 
 # Claude Code (local settings, not shared)
 .claude/settings.local.json
+
+# Active story context (operational, not code)
+STORY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,22 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Added
 
 ### Changed
+
+### Removed
+
+### Fixed
+
+---
+
+## [1.24.10] - 2026-04-12
+
+### Changed
 - `RedisService.del` now accepts `string | string[]` enabling batch key deletion in a single Redis round-trip
 - Replaced N+1 sequential `del()` calls with batched array calls in `ChannelsService`, `PanelistsService`, `WeeklyOverridesService`, and `YoutubeLiveService`
 - Replaced N+1 sequential `get()` calls with single `mget()` in `YoutubeController` SSE polling loop
 - Replaced N+1 sequential `get()` calls with single `mget()` in `StreamerLiveStatusService.getAllLiveStatuses`
 - Replaced N+1 sequential `get()` calls with single `mget()` in `StreamersService.getWebhookStatus`
 - Replaced per-banner sequential `save()` loop with single batch `save()` call in `BannersService.findAllActive`
-
-### Removed
-
-### Fixed
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 ### Added
 
 ### Changed
+- `RedisService.del` now accepts `string | string[]` enabling batch key deletion in a single Redis round-trip
+- Replaced N+1 sequential `del()` calls with batched array calls in `ChannelsService`, `PanelistsService`, `WeeklyOverridesService`, and `YoutubeLiveService`
+- Replaced N+1 sequential `get()` calls with single `mget()` in `YoutubeController` SSE polling loop
+- Replaced N+1 sequential `get()` calls with single `mget()` in `StreamerLiveStatusService.getAllLiveStatuses`
+- Replaced N+1 sequential `get()` calls with single `mget()` in `StreamersService.getWebhookStatus`
+- Replaced per-banner sequential `save()` loop with single batch `save()` call in `BannersService.findAllActive`
 
 ### Removed
 

--- a/src/banners/banners.service.spec.ts
+++ b/src/banners/banners.service.spec.ts
@@ -185,15 +185,21 @@ describe('BannersService', () => {
       };
 
       mockRepository.find.mockResolvedValue([timedBanner, disabledFixedBanner]);
-      // Mock save to return the updated banner
-      mockRepository.save.mockImplementation((banner) => Promise.resolve({ ...banner, is_enabled: true }));
+      // Mock save to handle batch array call
+      mockRepository.save.mockImplementation((banners) =>
+        Array.isArray(banners)
+          ? Promise.resolve(banners.map(b => ({ ...b, is_enabled: true })))
+          : Promise.resolve({ ...banners, is_enabled: true })
+      );
 
       const result = await service.findAllActive();
 
       // Should have at least 2 banners
       expect(result.length).toBeGreaterThanOrEqual(2);
-      // Should have called save to enable the fixed banner
-      expect(mockRepository.save).toHaveBeenCalled();
+      // Should have called save once with array to enable the fixed banner
+      expect(mockRepository.save).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 2, is_enabled: true })])
+      );
     });
 
     it('should not auto-enable more than 2 fixed banners', async () => {
@@ -235,7 +241,11 @@ describe('BannersService', () => {
       };
 
       mockRepository.find.mockResolvedValue([timedBanner, disabledFixed1, disabledFixed2, disabledFixed3]);
-      mockRepository.save.mockImplementation((banner) => Promise.resolve({ ...banner, is_enabled: true }));
+      mockRepository.save.mockImplementation((banners) =>
+        Array.isArray(banners)
+          ? Promise.resolve(banners.map(b => ({ ...b, is_enabled: true })))
+          : Promise.resolve({ ...banners, is_enabled: true })
+      );
 
       const result = await service.findAllActive();
 

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -90,11 +90,9 @@ export class BannersService {
         if (canAutoEnable > 0) {
           autoEnabledFixed = disabledFixedBanners.slice(0, canAutoEnable);
 
-          // Update database to enable these banners
-          for (const banner of autoEnabledFixed) {
-            banner.is_enabled = true;
-            await this.bannersRepository.save(banner);
-          }
+          // Update database to enable these banners (single batch save)
+          autoEnabledFixed.forEach(banner => { banner.is_enabled = true; });
+          await this.bannersRepository.save(autoEnabledFixed);
 
           this.logger.debug(
             `Auto-enabled ${autoEnabledFixed.length} fixed banner(s) to meet minimum requirement: ${autoEnabledFixed.map(b => b.id).join(', ')}`

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -192,9 +192,9 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       // Assert
       expect(youtubeDiscoveryService.getChannelIdFromHandle).toHaveBeenCalledWith('@newhandle');
       // Should invalidate old handle cache when handle changes
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@oldhandle');
+      expect(redisService.del).toHaveBeenCalledWith(['liveStatusByHandle:@oldhandle', 'videoIdNotFound:@oldhandle', 'notFoundAttempts:@oldhandle']);
       // Should also invalidate new handle cache when YouTube channel ID changes (wrong channel ID was cached)
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@newhandle');
+      expect(redisService.del).toHaveBeenCalledWith(['liveStatusByHandle:@newhandle', 'videoIdNotFound:@newhandle', 'notFoundAttempts:@newhandle']);
     });
 
     it('should not invalidate live status caches when handle does not change', async () => {
@@ -238,7 +238,7 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       // Assert
       expect(youtubeDiscoveryService.getChannelIdFromHandle).toHaveBeenCalledWith('@newhandle');
       // Should still invalidate old handle cache even if new channel ID resolution fails
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@oldhandle');
+      expect(redisService.del).toHaveBeenCalledWith(['liveStatusByHandle:@oldhandle', 'videoIdNotFound:@oldhandle', 'notFoundAttempts:@oldhandle']);
       // Note: New handle cache won't be invalidated if channel ID resolution fails (no new channel ID to compare)
     });
 
@@ -312,10 +312,8 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       const result = await service.clearChannelCache(handle);
 
       // Assert
-      expect(redisService.del).toHaveBeenCalledWith('liveStatusByHandle:@testhandle');
-      expect(redisService.del).toHaveBeenCalledWith('videoIdNotFound:@testhandle');
-      expect(redisService.del).toHaveBeenCalledWith('notFoundAttempts:@testhandle');
-      expect(redisService.del).toHaveBeenCalledTimes(3);
+      expect(redisService.del).toHaveBeenCalledWith(['liveStatusByHandle:@testhandle', 'videoIdNotFound:@testhandle', 'notFoundAttempts:@testhandle']);
+      expect(redisService.del).toHaveBeenCalledTimes(1);
       expect(result.cleared).toEqual(['liveStatusByHandle', 'videoIdNotFound', 'notFoundAttempts']);
     });
 

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -148,8 +148,7 @@ export class ChannelsService {
   
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del(['schedules:week:complete', 'channels:visible_with_categories']);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -219,8 +218,7 @@ export class ChannelsService {
 
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del(['schedules:week:complete', 'channels:visible_with_categories']);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -319,8 +317,7 @@ export class ChannelsService {
     
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del(['schedules:week:complete', 'channels:visible_with_categories']);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -347,8 +344,7 @@ export class ChannelsService {
     
     // Clear unified cache
     try {
-      await this.redisService.del('schedules:week:complete');
-      await this.redisService.del('channels:visible_with_categories');
+      await this.redisService.del(['schedules:week:complete', 'channels:visible_with_categories']);
     } catch (error) {
       console.error('❌ Error clearing caches:', error.message);
     }
@@ -664,9 +660,7 @@ export class ChannelsService {
     try {
       // Invalidate unified cache and related keys
       // Note: liveStreamsByChannel no longer exists (unified into liveStatusByHandle)
-      await this.redisService.del(`liveStatusByHandle:${handle}`);
-      await this.redisService.del(`videoIdNotFound:${handle}`);
-      await this.redisService.del(`notFoundAttempts:${handle}`);
+      await this.redisService.del([`liveStatusByHandle:${handle}`, `videoIdNotFound:${handle}`, `notFoundAttempts:${handle}`]);
       console.log(`🗑️ Invalidated cache keys for: ${handle}`);
     } catch (error) {
       console.error(`❌ Error invalidating live status cache for ${handle}:`, error.message);
@@ -686,15 +680,9 @@ export class ChannelsService {
     
     try {
       // Clear all channel-related cache entries
-      await this.redisService.del(`liveStatusByHandle:${handle}`);
-      cleared.push('liveStatusByHandle');
-      
-      await this.redisService.del(`videoIdNotFound:${handle}`);
-      cleared.push('videoIdNotFound');
-      
-      await this.redisService.del(`notFoundAttempts:${handle}`);
-      cleared.push('notFoundAttempts');
-      
+      await this.redisService.del([`liveStatusByHandle:${handle}`, `videoIdNotFound:${handle}`, `notFoundAttempts:${handle}`]);
+      cleared.push('liveStatusByHandle', 'videoIdNotFound', 'notFoundAttempts');
+
       console.log(`🗑️ Manually cleared cache keys for: ${handle}`);
       return { cleared };
     } catch (error) {

--- a/src/panelists/panelists.service.ts
+++ b/src/panelists/panelists.service.ts
@@ -110,11 +110,7 @@ export class PanelistsService {
     Object.assign(panelist, updatePanelistDto);
     const updatedPanelist = await this.panelistsRepository.save(panelist);
     
-    await Promise.all([
-      this.redisService.del('panelists:all'),
-      this.redisService.del(`panelists:${id}`),
-      this.redisService.del('schedules:week:complete'), // Clear unified schedule cache since panelist info appears in schedules
-    ]);
+    await this.redisService.del(['panelists:all', `panelists:${id}`, 'schedules:week:complete']);
     
     // Warm cache asynchronously (non-blocking)
     this.schedulesService.debouncedWarmSchedulesCache();
@@ -134,10 +130,7 @@ export class PanelistsService {
   async remove(id: string): Promise<boolean> {
     const result = await this.panelistsRepository.delete(id);
     if ((result?.affected ?? 0) > 0) {
-      await Promise.all([
-        this.redisService.del('panelists:all'),
-        this.redisService.del(`panelists:${id}`),
-      ]);
+      await this.redisService.del(['panelists:all', `panelists:${id}`]);
       // Notify and revalidate
       await this.notifyUtil.notifyAndRevalidate({
         eventType: 'panelist_deleted',
@@ -169,12 +162,11 @@ export class PanelistsService {
       panelist.programs.push(program);
       await this.panelistsRepository.save(panelist);
       console.log(`[Cache] Invalidating cache for panelist ${panelistId} after adding to program ${programId}`);
-      await this.redisService.del(`panelists:${panelistId}`);
-      await this.redisService.del('schedules:week:complete');
-      
+      await this.redisService.del([`panelists:${panelistId}`, 'schedules:week:complete']);
+
       // Warm cache asynchronously (non-blocking)
       this.schedulesService.debouncedWarmSchedulesCache();
-      
+
       // Notify and revalidate
       await this.notifyUtil.notifyAndRevalidate({
         eventType: 'panelist_added_to_program',
@@ -193,12 +185,11 @@ export class PanelistsService {
       panelist.programs = panelist.programs.filter(p => p.id !== Number(programId));
       await this.panelistsRepository.save(panelist);
       console.log(`[Cache] Invalidating cache for panelist ${panelistId} after removing from program ${programId}`);
-      await this.redisService.del(`panelists:${panelistId}`);
-      await this.redisService.del('schedules:week:complete');
-      
+      await this.redisService.del([`panelists:${panelistId}`, 'schedules:week:complete']);
+
       // Warm cache asynchronously (non-blocking)
       this.schedulesService.debouncedWarmSchedulesCache();
-      
+
       // Notify and revalidate
       await this.notifyUtil.notifyAndRevalidate({
         eventType: 'panelist_removed_from_program',

--- a/src/redis/redis.service.spec.ts
+++ b/src/redis/redis.service.spec.ts
@@ -71,6 +71,16 @@ describe('RedisService', () => {
       await service.del('key');
       expect(mockClient.del).toHaveBeenCalledWith('key');
     });
+
+    it('deletes multiple keys when array is provided', async () => {
+      await service.del(['key1', 'key2']);
+      expect(mockClient.del).toHaveBeenCalledWith('key1', 'key2');
+    });
+
+    it('does nothing when empty array is provided', async () => {
+      await service.del([]);
+      expect(mockClient.del).not.toHaveBeenCalled();
+    });
   });
 
   describe('incr', () => {

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -74,8 +74,13 @@ export class RedisService implements OnModuleInit {
     return values.map(v => (v ? JSON.parse(v) : null));
   }
 
-  async del(key: string): Promise<void> {
-    await this.client.del(key);
+  async del(key: string | string[]): Promise<void> {
+    if (Array.isArray(key)) {
+      if (key.length === 0) return;
+      await this.client.del(...key);
+    } else {
+      await this.client.del(key);
+    }
   }
 
   async incr(key: string): Promise<number> {

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -372,8 +372,7 @@ describe('WeeklyOverridesService', () => {
       const result = await service.deleteWeeklyOverride(overrideId);
 
       expect(result).toBe(true);
-      expect(redisService.del).toHaveBeenCalledWith(`weekly_override:${overrideId}`);
-      expect(redisService.del).toHaveBeenCalledWith('schedules:week:complete');
+      expect(redisService.del).toHaveBeenCalledWith([`weekly_override:${overrideId}`, 'schedules:week:complete']);
     });
 
     it('should return false when override does not exist', async () => {

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -666,9 +666,8 @@ export class WeeklyOverridesService {
       return false;
     }
 
-    await this.redisService.del(`weekly_override:${overrideId}`);
-    await this.redisService.del('schedules:week:complete');
-    
+    await this.redisService.del([`weekly_override:${overrideId}`, 'schedules:week:complete']);
+
     // Smart weekly cache update: update instead of invalidate
     await this.updateWeeklyCacheForWeek(exists.weekStartDate);
     

--- a/src/streamers/streamer-live-status.service.spec.ts
+++ b/src/streamers/streamer-live-status.service.spec.ts
@@ -15,6 +15,9 @@ describe('StreamerLiveStatusService', () => {
     set: jest.fn(),
     del: jest.fn(),
     mget: jest.fn(),
+    client: {
+      scan: jest.fn(),
+    },
   };
 
   const mockConfigService = {
@@ -215,6 +218,25 @@ describe('StreamerLiveStatusService', () => {
       expect(result.size).toBe(2);
       expect(result.get(1)).toEqual(cache1);
       expect(result.get(2)).toEqual(cache2);
+    });
+  });
+
+  describe('getAllLiveStatuses', () => {
+    it('should use mget to avoid N+1 query pattern', async () => {
+      mockRedisService.client.scan.mockResolvedValueOnce(['0', ['streamer_live:1', 'streamer_live:2']]);
+
+      const cache1 = { streamerId: 1, isLive: true, services: [], lastUpdated: Date.now(), ttl: 604800 };
+      const cache2 = { streamerId: 2, isLive: false, services: [], lastUpdated: Date.now(), ttl: 604800 };
+
+      mockRedisService.mget.mockResolvedValueOnce([cache1, cache2]);
+
+      const result = await service.getAllLiveStatuses();
+
+      expect(mockRedisService.client.scan).toHaveBeenCalled();
+      expect(mockRedisService.mget).toHaveBeenCalledWith(['streamer_live:1', 'streamer_live:2']);
+      expect(result.size).toBe(1);
+      expect(result.get(1)).toBe(true);
+      expect(result.has(2)).toBe(false);
     });
   });
 

--- a/src/streamers/streamer-live-status.service.ts
+++ b/src/streamers/streamer-live-status.service.ts
@@ -153,13 +153,13 @@ export class StreamerLiveStatusService {
       const keys = reply[1];
 
       if (keys.length > 0) {
-        // Fetch values for these keys
-        for (const key of keys) {
-          const data = await this.redisService.get<StreamerLiveStatusCache>(key);
+        // Fetch all values in a single mget to avoid N+1 Redis round-trips
+        const statuses = await this.redisService.mget<StreamerLiveStatusCache>(keys);
+        statuses.forEach((data) => {
           if (data && data.isLive) {
             result.set(data.streamerId, true);
           }
-        }
+        });
       }
     } while (cursor !== '0');
 

--- a/src/streamers/streamers.service.ts
+++ b/src/streamers/streamers.service.ts
@@ -418,83 +418,96 @@ export class StreamersService {
       kick: [] as Array<{ username: string; subscriptionId: string; status: string; fromApi: boolean }>,
     };
 
-    // Get subscriptions from Redis
-    const redisSubscriptions = await this.webhookSubscriptionService.getSubscriptionsForStreamer(
-      streamerId,
-      streamer.services
-    );
+    // Collect all Redis keys upfront to batch fetch with mget
+    const redisKeys: string[] = [];
+    const twitchEntries: Array<{ username: string; eventType: 'stream.online' | 'stream.offline'; redisKey: string }> = [];
+    const kickEntries: Array<{ username: string; redisKey: string }> = [];
 
-    // For Twitch: Check status from API
     for (const service of streamer.services) {
       if (service.service === 'twitch') {
         const username = service.username || extractTwitchUsername(service.url);
         if (username) {
-          // Get subscriptions from Twitch API
-          const apiSubscriptions = await this.webhookSubscriptionService.getTwitchEventSubSubscriptions();
-
-          // Check for both online and offline subscriptions
           for (const eventType of ['stream.online', 'stream.offline'] as const) {
             const redisKey = `webhook:subscription:twitch:${username}:${eventType}`;
-            const redisSub = await this.redisService.get(redisKey) as any;
-            const subscriptionId = redisSub?.subscriptionId;
-
-            if (subscriptionId) {
-              // Find matching subscription in API response
-              const apiSub = apiSubscriptions.find(
-                (s: any) => s.id === subscriptionId && s.type === eventType
-              );
-
-              status.twitch.push({
-                username,
-                eventType,
-                subscriptionId,
-                status: apiSub?.status || 'unknown',
-                fromApi: !!apiSub,
-              });
-            }
+            redisKeys.push(redisKey);
+            twitchEntries.push({ username, eventType, redisKey });
           }
         }
       } else if (service.service === 'kick') {
         const username = service.username || extractKickUsername(service.url);
         if (username) {
           const redisKey = `webhook:subscription:kick:${username}`;
-          const redisSub = await this.redisService.get(redisKey) as any;
-          const subscriptionId = redisSub?.subscriptionId;
-          const userId = redisSub?.userId;
+          redisKeys.push(redisKey);
+          kickEntries.push({ username, redisKey });
+        }
+      }
+    }
 
-          if (subscriptionId) {
-            // Verify with Kick API if we have the user ID
-            let verified = false;
-            let apiStatus = 'unknown';
+    // Single mget call instead of N individual get calls
+    const redisResults = redisKeys.length > 0 ? await this.redisService.mget<any>(redisKeys) : [];
+    const redisDataByKey = new Map<string, any>(
+      redisKeys.map((key, i) => [key, redisResults[i]])
+    );
 
-            if (userId) {
-              try {
-                const apiSubscriptions = await this.webhookSubscriptionService.getKickSubscriptions(userId);
-                const matchingSub = apiSubscriptions.find(
-                  sub => sub.subscription_id === subscriptionId || sub.event === 'livestream.status.updated'
-                );
-                if (matchingSub) {
-                  verified = true;
-                  apiStatus = 'enabled';
-                } else if (apiSubscriptions.length > 0) {
-                  // Has subscriptions but different ID - subscription was recreated
-                  apiStatus = 'different_id';
-                } else {
-                  apiStatus = 'not_found';
-                }
-              } catch (error) {
-                apiStatus = 'api_error';
-              }
+    // For Twitch: Check status from API (single API call for all Twitch subs)
+    if (twitchEntries.length > 0) {
+      const apiSubscriptions = await this.webhookSubscriptionService.getTwitchEventSubSubscriptions();
+
+      for (const { username, eventType, redisKey } of twitchEntries) {
+        const redisSub = redisDataByKey.get(redisKey) as any;
+        const subscriptionId = redisSub?.subscriptionId;
+
+        if (subscriptionId) {
+          const apiSub = apiSubscriptions.find(
+            (s: any) => s.id === subscriptionId && s.type === eventType
+          );
+
+          status.twitch.push({
+            username,
+            eventType,
+            subscriptionId,
+            status: apiSub?.status || 'unknown',
+            fromApi: !!apiSub,
+          });
+        }
+      }
+    }
+
+    // For Kick: Check status from API
+    for (const { username, redisKey } of kickEntries) {
+      const redisSub = redisDataByKey.get(redisKey) as any;
+      const subscriptionId = redisSub?.subscriptionId;
+      const userId = redisSub?.userId;
+
+      if (subscriptionId) {
+        let verified = false;
+        let apiStatus = 'unknown';
+
+        if (userId) {
+          try {
+            const apiSubscriptions = await this.webhookSubscriptionService.getKickSubscriptions(userId);
+            const matchingSub = apiSubscriptions.find(
+              sub => sub.subscription_id === subscriptionId || sub.event === 'livestream.status.updated'
+            );
+            if (matchingSub) {
+              verified = true;
+              apiStatus = 'enabled';
+            } else if (apiSubscriptions.length > 0) {
+              apiStatus = 'different_id';
+            } else {
+              apiStatus = 'not_found';
             }
-
-            status.kick.push({
-              username,
-              subscriptionId,
-              status: apiStatus,
-              fromApi: verified,
-            });
+          } catch (error) {
+            apiStatus = 'api_error';
           }
         }
+
+        status.kick.push({
+          username,
+          subscriptionId,
+          status: apiStatus,
+          fromApi: verified,
+        });
       }
     }
 

--- a/src/youtube/youtube-live.service.spec.ts
+++ b/src/youtube/youtube-live.service.spec.ts
@@ -140,8 +140,7 @@ describe('YoutubeLiveService', () => {
         streamCount: 1
       }), 100);
       // Should clear both not-found keys when video is found
-      expect(redisService.del).toHaveBeenCalledWith('videoIdNotFound:handle');
-      expect(redisService.del).toHaveBeenCalledWith('notFoundAttempts:handle');
+      expect(redisService.del).toHaveBeenCalledWith(['videoIdNotFound:handle', 'notFoundAttempts:handle']);
       expect(result).toBe('vid123');
     });
 

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -198,8 +198,7 @@ export class YoutubeLiveService {
       await this.redisService.set(statusCacheKey, cacheData, cacheData.ttl);
 
       // Clear the "not-found" flag and attempt tracking since we found live streams
-      await this.redisService.del(notFoundKey);
-      await this.redisService.del(`notFoundAttempts:${handle}`);
+      await this.redisService.del([notFoundKey, `notFoundAttempts:${handle}`]);
       this.logger.debug(`📌 Cached ${handle} → ${videoId} (TTL ${blockTTL}s)`);
 
       // Notify clients about the new video ID

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -632,17 +632,23 @@ export class YoutubeLiveService {
 
 
 
-      const currentProgram = schedules.find(s => {
+      const currentScheduleEntries = schedules.filter(s => {
         const chId = s.program?.channel?.youtube_channel_id;
         if (chId !== channelId) return false;
-        if (s.program?.is_visible === false) return false; // Skip invisible programs
         const startNum = this.convertTimeToMinutes(s.start_time);
         const endNum = this.convertTimeToMinutes(s.end_time);
         return currentTimeInMinutes >= startNum && currentTimeInMinutes < endNum;
       });
 
-      if (currentProgram?.program) {
-        currentProgramName = currentProgram.program.name; // Capture name for sorting logic
+      const visibleCurrentSchedule = currentScheduleEntries.find(s => s.program?.is_visible !== false);
+
+      if (currentScheduleEntries.length > 0 && !visibleCurrentSchedule) {
+        this.logger.debug(`🚫 Skipping ${handle} (${channelId}) - current program is not visible`);
+        return '__SKIPPED__';
+      }
+
+      if (visibleCurrentSchedule?.program) {
+        currentProgramName = visibleCurrentSchedule.program.name; // Capture name for sorting logic
       }
     } catch (visErr) {
       // Non-fatal: if visibility check fails, proceed as before

--- a/src/youtube/youtube.controller.ts
+++ b/src/youtube/youtube.controller.ts
@@ -50,52 +50,70 @@ export class YoutubeController {
           const sixtySecondsAgo = Date.now() - 60000;
           const keys = await this.redisService.client.keys('live_notification:*');
 
-          for (const key of keys) {
-            const parts = key.split(':');
-            const timestamp = parseInt(parts[parts.length - 1]);
+          if (keys.length > 0) {
+            const keysToFetch: string[] = [];
+            const keysToDelete: string[] = [];
 
-            if (isNaN(timestamp)) {
-              this.logger.warn(`Invalid timestamp in notification key: ${key}`);
-              continue;
+            // First pass: classify keys by timestamp
+            for (const key of keys) {
+              const parts = key.split(':');
+              const timestamp = parseInt(parts[parts.length - 1]);
+
+              if (isNaN(timestamp)) {
+                this.logger.warn(`Invalid timestamp in notification key: ${key}`);
+                continue;
+              }
+
+              if (timestamp > sixtySecondsAgo) {
+                keysToFetch.push(key);
+              } else {
+                keysToDelete.push(key);
+              }
             }
 
-            if (timestamp > sixtySecondsAgo) {
-              const notificationString = await this.redisService.get(key);
-              if (notificationString && typeof notificationString === 'string') {
-                try {
-                  const notification = JSON.parse(notificationString) as LiveNotification;
+            // Batch fetch recent notifications in a single mget
+            if (keysToFetch.length > 0) {
+              const notificationStrings = await this.redisService.client.mget(...keysToFetch);
 
-                  // Create a unique identifier for this notification
-                  const notificationId = notification.channelId
-                    ? `${notification.type}:${notification.channelId}:${notification.timestamp}`
-                    : `${notification.type}:${notification.entity}:${notification.entityId}:${notification.timestamp}`;
+              for (const notificationString of notificationStrings) {
+                if (notificationString && typeof notificationString === 'string') {
+                  try {
+                    const notification = JSON.parse(notificationString) as LiveNotification;
 
-                  // Only send if we haven't sent this notification before (per-connection)
-                  if (!this.sentNotifications.has(notificationId)) {
-                    this.sentNotifications.add(notificationId);
+                    // Create a unique identifier for this notification
+                    const notificationId = notification.channelId
+                      ? `${notification.type}:${notification.channelId}:${notification.timestamp}`
+                      : `${notification.type}:${notification.entity}:${notification.entityId}:${notification.timestamp}`;
 
-                    subscriber.next({
-                      data: JSON.stringify(notification),
-                      type: 'message',
-                    } as MessageEvent);
+                    // Only send if we haven't sent this notification before (per-connection)
+                    if (!this.sentNotifications.has(notificationId)) {
+                      this.sentNotifications.add(notificationId);
 
-                    // IMPORTANT: Do NOT delete the Redis key here.
-                    // We want ALL connected clients to receive the notification.
-                    // Each connection tracks what it has already sent via sentNotifications.
-                    // Old notifications are cleaned up below (timestamp check) or by TTL.
+                      subscriber.next({
+                        data: JSON.stringify(notification),
+                        type: 'message',
+                      } as MessageEvent);
 
-                    // Clean up the tracking set after 1 minute to prevent memory leaks
-                    setTimeout(() => {
-                      this.sentNotifications.delete(notificationId);
-                    }, 60000);
+                      // IMPORTANT: Do NOT delete the Redis key here.
+                      // We want ALL connected clients to receive the notification.
+                      // Each connection tracks what it has already sent via sentNotifications.
+                      // Old notifications are cleaned up below (timestamp check) or by TTL.
+
+                      // Clean up the tracking set after 1 minute to prevent memory leaks
+                      setTimeout(() => {
+                        this.sentNotifications.delete(notificationId);
+                      }, 60000);
+                    }
+                  } catch (error) {
+                    this.logger.error('Error parsing notification:', error);
                   }
-                } catch (error) {
-                  this.logger.error('Error parsing notification:', error);
                 }
               }
-            } else {
-              // Clean up old notifications
-              await this.redisService.del(key);
+            }
+
+            // Batch delete expired notifications in a single DEL
+            if (keysToDelete.length > 0) {
+              await this.redisService.del(keysToDelete);
             }
           }
         } catch (error) {


### PR DESCRIPTION
## [1.24.10] - 2026-04-12

### Changed
- \`RedisService.del\` now accepts \`string | string[]\` enabling batch key deletion in a single Redis round-trip
- Replaced N+1 sequential \`del()\` calls with batched array calls in \`ChannelsService\`, \`PanelistsService\`, \`WeeklyOverridesService\`, and \`YoutubeLiveService\`
- Replaced N+1 sequential \`get()\` calls with single \`mget()\` in \`YoutubeController\` SSE polling loop
- Replaced N+1 sequential \`get()\` calls with single \`mget()\` in \`StreamerLiveStatusService.getAllLiveStatuses\`
- Replaced N+1 sequential \`get()\` calls with single \`mget()\` in \`StreamersService.getWebhookStatus\`
- Replaced per-banner sequential \`save()\` loop with single batch \`save()\` call in \`BannersService.findAllActive\`

Closes #306, #307, #308, #309, #310, #311