### PR TITLE
⚡ Bolt: [performance improvement] Batched Redis operations in weekly overrides

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,10 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2025-04-17 - [N+1 Redis Query Avoidance with MGET and Chunking]
+**Learning:** Found sequential Redis  and  patterns inside the  and  methods. Also, when transitioning to , large volumes of keys retrieved via  could blow up the stack or overload the connection if requested all at once.
+**Action:** Replace sequential  calls with batched  retrievals processed in chunks (e.g., 500 keys at a time) to avoid call stack limits. Consolidate keys to delete and invoke a single .
+
+## 2025-04-17 - [N+1 Redis Query Avoidance with MGET and Chunking]
+**Learning:** Found sequential Redis `get` and `del` patterns inside the `deleteOverridesForProgram` and `cleanupExpiredOverrides` methods. Also, when transitioning to `mget`, large volumes of keys retrieved via `scanStream` could blow up the stack or overload the connection if requested all at once.
+**Action:** Replace sequential `get` calls with batched `mget` retrievals processed in chunks (e.g., 500 keys at a time) to avoid call stack limits. Consolidate keys to delete and invoke a single `this.redisService.del(array)`.

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -30,6 +30,7 @@ describe('WeeklyOverridesService', () => {
 
     const mockRedisService = {
       get: jest.fn(),
+      mget: jest.fn(),
       set: jest.fn(),
       del: jest.fn(),
       delByPattern: jest.fn(),
@@ -760,7 +761,7 @@ describe('WeeklyOverridesService', () => {
       const result = await service.cleanupExpiredOverrides();
 
       expect(result).toBe(1);
-      expect(redisService.del).toHaveBeenCalledWith('weekly_override:1_2024-01-01');
+      expect(redisService.del).toHaveBeenCalledWith(['weekly_override:1_2024-01-01']);
       expect(redisService.del).toHaveBeenCalledWith('schedules:week:complete');
     });
 

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -951,9 +951,9 @@ export class WeeklyOverridesService {
       });
       
       // Delete expired overrides
-      for (const key of expiredKeys) {
-        await this.redisService.del(key);
-        cleaned++;
+      if (expiredKeys.length > 0) {
+        await this.redisService.del(expiredKeys);
+        cleaned = expiredKeys.length;
       }
     }
 
@@ -977,18 +977,30 @@ export class WeeklyOverridesService {
     for await (const keyChunk of stream) {
       keys.push(...keyChunk);
     }
-    let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
-      }
+    const keysToDelete: string[] = [];
+    const BATCH_SIZE = 500;
+
+    // Batch retrieve keys to avoid N+1 Redis gets
+    for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+      const batchKeys = keys.slice(i, i + BATCH_SIZE);
+      const batchValues = await this.redisService.mget<WeeklyOverride>(batchKeys);
+
+      batchValues.forEach((override, index) => {
+        if (!override) return;
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          keysToDelete.push(batchKeys[index]);
+        }
+      });
     }
+
+    if (keysToDelete.length > 0) {
+      // Batch delete to avoid N+1 Redis dels
+      await this.redisService.del(keysToDelete);
+    }
+    const deleted = keysToDelete.length;
     if (deleted > 0) {
       await this.redisService.del('schedules:week:complete');
       


### PR DESCRIPTION
💡 **What:** Replaced sequential `await this.redisService.get(key)` and `await this.redisService.del(key)` calls inside loops within `src/schedules/weekly-overrides.service.ts` with batched `mget` and `del` operations. Chunking was implemented for `mget` to avoid call stack limits.
🎯 **Why:** To eliminate an N+1 Redis query anti-pattern that caused poor performance when retrieving and deleting a large list of weekly override keys.
📊 **Impact:** Reduces Redis I/O overhead heavily by converting N distinct network trips into O(N/500) trips for retrieval and 1 round-trip for deletion.
🔬 **Measurement:** Code correctly passes all unit tests natively when running `npm test`. Performance improvement directly translates to minimal network latency delays on these functions.

---
*PR created automatically by Jules for task [11579378673974728420](https://jules.google.com/task/11579378673974728420) started by @matiasrozenblum*