### PR TITLE
⚡ Bolt: [performance improvement] Batch Redis queries in deleteOverridesForProgram

### DIFF
--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -978,17 +978,34 @@ export class WeeklyOverridesService {
       keys.push(...keyChunk);
     }
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+
+    // Process in chunks to avoid maximum call stack size limits or Redis overload
+    const CHUNK_SIZE = 500;
+    for (let i = 0; i < keys.length; i += CHUNK_SIZE) {
+      const chunkKeys = keys.slice(i, i + CHUNK_SIZE);
+      if (chunkKeys.length === 0) continue;
+
+      const chunkOverrides = await this.redisService.mget<WeeklyOverride>(chunkKeys);
+      const chunkKeysToDelete: string[] = [];
+
+      for (let j = 0; j < chunkOverrides.length; j++) {
+        const override = chunkOverrides[j];
+        if (!override) continue;
+
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          chunkKeysToDelete.push(chunkKeys[j]);
+          deleted++;
+        }
+      }
+
+      if (chunkKeysToDelete.length > 0) {
+        await this.redisService.del(chunkKeysToDelete);
       }
     }
+
     if (deleted > 0) {
       await this.redisService.del('schedules:week:complete');
       


### PR DESCRIPTION
💡 **What**: Refactored the `deleteOverridesForProgram` method in `WeeklyOverridesService` to use a chunked batch processing approach for Redis operations. Replaced sequential `.get()` and `.del()` with batch `.mget()` and a single batched `.del()`.
🎯 **Why**: To prevent N+1 query patterns that could occur when resolving scan results for thousands of weekly override keys. This avoids multiple round trips, max call stack limits, and significantly reduces connection overhead to Redis.
📊 **Impact**: Expected to drastically reduce completion times of bulk overriding deletion tasks and eliminate potential Node stack exhaustion or Redis overload under heavy traffic or a large number of schedule changes.
🔬 **Measurement**: Verified the test suite still passes successfully with correct logic behavior maintained. Replaced 2N roundtrips with `(N/500)*2` roundtrips per batch execution.

---
*PR created automatically by Jules for task [10741213542058306567](https://jules.google.com/task/10741213542058306567) started by @matiasrozenblum*