### PR TITLE
⚡ Bolt: [performance improvement] Batched Redis queries in overrides deletion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-05-18 - [N+1 Redis Query Avoidance in Overrides Deletion]
+**Learning:** The `deleteOverridesForProgram` function fetched each Redis key sequentially using `await this.redisService.get(key)` and deleted them sequentially using `await this.redisService.del(key)` in a large iteration loop, causing severe latency and connection overhead due to N+1 Redis network round-trips.
+**Action:** Use chunking to batch fetch using `await this.redisService.mget(keys)` and consolidate deletions into a single `await this.redisService.del(keysToDelete)` call to minimize network I/O operations.

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -978,17 +978,35 @@ export class WeeklyOverridesService {
       keys.push(...keyChunk);
     }
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+
+    // Process in batches to avoid maximum call stack size limits or Redis overload
+    const batchSize = 500;
+    const keysToDelete: string[] = [];
+
+    for (let i = 0; i < keys.length; i += batchSize) {
+      const batchKeys = keys.slice(i, i + batchSize);
+      if (batchKeys.length === 0) continue;
+
+      const overrides = await this.redisService.mget<WeeklyOverride>(batchKeys);
+
+      for (let j = 0; j < batchKeys.length; j++) {
+        const override = overrides[j];
+        if (!override) continue;
+
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          keysToDelete.push(batchKeys[j]);
+        }
       }
     }
+
+    if (keysToDelete.length > 0) {
+      await this.redisService.del(keysToDelete);
+      deleted = keysToDelete.length;
+    }
+
     if (deleted > 0) {
       await this.redisService.del('schedules:week:complete');
       


### PR DESCRIPTION
💡 What: Replaced sequential `redisService.get` and `redisService.del` calls inside a loop with batched `mget` calls (chunked by 500) and a single `del(keysToDelete)` batch call in `deleteOverridesForProgram`.

🎯 Why: The previous implementation performed an N+1 query pattern where it fetched and deleted each Redis key individually, causing connection overhead and high latency when processing many keys.

📊 Impact: Reduces Redis network round-trips from O(N) to O(N/500) for fetch and O(1) for deletion. Should result in much faster bulk deletion performance with lower latency and fewer chances of connection pooling exhaustion.

🔬 Measurement: Verify by executing bulk deletion of schedules and observing the reduction in latency and number of Redis commands executed. Added a new memory note for bolt.md.

---
*PR created automatically by Jules for task [6784839266580675444](https://jules.google.com/task/6784839266580675444) started by @matiasrozenblum*