### PR TITLE
⚡ Bolt: Fix N+1 Redis query bottlenecks in weekly overrides cleanup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2024-05-15 - Batched Redis Deletions
+**Learning:** In operations that retrieve or delete multiple Redis keys in loops (e.g. `deleteOverridesForProgram`, `cleanupExpiredOverrides`), using individual `get` and `del` creates N+1 query patterns that hit Redis repeatedly, causing significant slowdowns on large data sets. Redis clients like `ioredis` support taking arrays of keys for operations like `del` and `mget`.
+**Action:** When finding loops running multiple Redis operations, batch them by collecting the keys, chunking them (to prevent payload/call stack limits), and using `mget` and `del([...keys])`.

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1,4 +1,11 @@
-import { Injectable, BadRequestException, NotFoundException, Inject, forwardRef, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  Inject,
+  forwardRef,
+  Logger,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, In, DataSource } from 'typeorm';
 import { Schedule } from './schedules.entity';
@@ -10,7 +17,8 @@ import * as utc from 'dayjs/plugin/utc';
 import * as timezone from 'dayjs/plugin/timezone';
 import * as updateLocale from 'dayjs/plugin/updateLocale';
 
-const FRONTEND_URL = process.env.FRONTEND_URL || 'https://staging.laguiadelstreaming.com';
+const FRONTEND_URL =
+  process.env.FRONTEND_URL || 'https://staging.laguiadelstreaming.com';
 const REVALIDATE_SECRET = process.env.REVALIDATE_SECRET || 'changeme';
 
 export interface WeeklyOverrideDto {
@@ -48,7 +56,8 @@ export interface WeeklyOverride {
   expiresAt: string; // Format: YYYY-MM-DD HH:mm:ss (Buenos Aires time)
   createdAt: Date;
   panelistIds?: number[]; // Array of panelist IDs assigned to this override (legacy, kept for backward compatibility)
-  panelists?: Array<{ // Complete panelist objects for fast access
+  panelists?: Array<{
+    // Complete panelist objects for fast access
     id: number;
     name: string;
     photo_url?: string | null;
@@ -59,7 +68,8 @@ export interface WeeklyOverride {
     name: string;
     description?: string;
     channelId: number; // Legacy, kept for backward compatibility
-    channel?: { // Complete channel object for fast access
+    channel?: {
+      // Complete channel object for fast access
       id: number;
       name: string;
       handle: string;
@@ -87,11 +97,13 @@ export class WeeklyOverridesService {
     private panelistsRepository: Repository<Panelist>,
     private readonly redisService: RedisService,
     private readonly dataSource: DataSource,
-    @Inject(forwardRef(() => {
-      // Lazy import to avoid circular dependency at module load time
-      const { SchedulesService } = require('./schedules.service');
-      return SchedulesService;
-    }))
+    @Inject(
+      forwardRef(() => {
+        // Lazy import to avoid circular dependency at module load time
+        const { SchedulesService } = require('./schedules.service');
+        return SchedulesService;
+      }),
+    )
     private readonly schedulesService: any,
   ) {
     this.dayjs = dayjs;
@@ -100,12 +112,12 @@ export class WeeklyOverridesService {
     this.dayjs.extend(updateLocale);
     // Set Monday as the first day of the week
     this.dayjs.updateLocale('en', {
-      weekStart: 1
+      weekStart: 1,
     });
     this.notifyUtil = new NotifyAndRevalidateUtil(
       this.redisService,
       FRONTEND_URL,
-      REVALIDATE_SECRET
+      REVALIDATE_SECRET,
     );
   }
 
@@ -115,11 +127,15 @@ export class WeeklyOverridesService {
   async createWeeklyOverride(dto: WeeklyOverrideDto): Promise<WeeklyOverride> {
     // Validate that either scheduleId or programId is provided (but not both)
     if (dto.scheduleId && dto.programId) {
-      throw new BadRequestException('Cannot provide both scheduleId and programId. Use one or the other.');
+      throw new BadRequestException(
+        'Cannot provide both scheduleId and programId. Use one or the other.',
+      );
     }
 
     if (!dto.scheduleId && !dto.programId && dto.overrideType !== 'create') {
-      throw new BadRequestException('Either scheduleId or programId is required for non-create overrides');
+      throw new BadRequestException(
+        'Either scheduleId or programId is required for non-create overrides',
+      );
     }
 
     // Validate schedule exists (only for non-create overrides with scheduleId)
@@ -130,7 +146,9 @@ export class WeeklyOverridesService {
       });
 
       if (!schedule) {
-        throw new NotFoundException(`Schedule with ID ${dto.scheduleId} not found`);
+        throw new NotFoundException(
+          `Schedule with ID ${dto.scheduleId} not found`,
+        );
       }
     }
 
@@ -142,47 +160,66 @@ export class WeeklyOverridesService {
       });
 
       if (!program) {
-        throw new NotFoundException(`Program with ID ${dto.programId} not found`);
+        throw new NotFoundException(
+          `Program with ID ${dto.programId} not found`,
+        );
       }
     }
 
     // Validate special program data for create overrides
     if (dto.overrideType === 'create') {
       if (!dto.specialProgram) {
-        throw new BadRequestException('Special program data is required for create overrides');
+        throw new BadRequestException(
+          'Special program data is required for create overrides',
+        );
       }
       if (!dto.specialProgram.name || !dto.specialProgram.channelId) {
-        throw new BadRequestException('Special program name and channelId are required');
+        throw new BadRequestException(
+          'Special program name and channelId are required',
+        );
       }
       if (!dto.newStartTime || !dto.newEndTime || !dto.newDayOfWeek) {
-        throw new BadRequestException('Start time, end time, and day of week are required for create overrides');
+        throw new BadRequestException(
+          'Start time, end time, and day of week are required for create overrides',
+        );
       }
     }
 
     // Calculate target week
     const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
     let targetWeekStart: dayjs.Dayjs;
-    
+
     if (dto.targetWeek === 'current') {
       targetWeekStart = now.startOf('week');
     } else if (dto.targetWeek === 'next') {
       targetWeekStart = now.add(1, 'week').startOf('week');
     } else {
-      throw new BadRequestException('targetWeek must be either "current" or "next"');
+      throw new BadRequestException(
+        'targetWeek must be either "current" or "next"',
+      );
     }
 
     const weekStartDate = targetWeekStart.format('YYYY-MM-DD');
     // Set expiration to next Monday at 00:00 Buenos Aires time
-    const expiresAt = targetWeekStart.add(1, 'week').format('YYYY-MM-DD HH:mm:ss');
+    const expiresAt = targetWeekStart
+      .add(1, 'week')
+      .format('YYYY-MM-DD HH:mm:ss');
 
     // Validate override type requirements
-    if ((dto.overrideType === 'time_change' || dto.overrideType === 'reschedule') && 
-        (!dto.newStartTime || !dto.newEndTime)) {
-      throw new BadRequestException('New start time and end time are required for time changes and reschedules');
+    if (
+      (dto.overrideType === 'time_change' ||
+        dto.overrideType === 'reschedule') &&
+      (!dto.newStartTime || !dto.newEndTime)
+    ) {
+      throw new BadRequestException(
+        'New start time and end time are required for time changes and reschedules',
+      );
     }
 
     if (dto.overrideType === 'reschedule' && !dto.newDayOfWeek) {
-      throw new BadRequestException('New day of week is required for reschedules');
+      throw new BadRequestException(
+        'New day of week is required for reschedules',
+      );
     }
 
     // Validate and fetch complete panelist objects if provided
@@ -192,9 +229,13 @@ export class WeeklyOverridesService {
         where: { id: In(dto.panelistIds) },
       });
       if (panelists.length !== dto.panelistIds.length) {
-        const foundIds = panelists.map(p => p.id);
-        const missingIds = dto.panelistIds.filter(id => !foundIds.includes(id));
-        throw new NotFoundException(`Panelists with IDs ${missingIds.join(', ')} not found`);
+        const foundIds = panelists.map((p) => p.id);
+        const missingIds = dto.panelistIds.filter(
+          (id) => !foundIds.includes(id),
+        );
+        throw new NotFoundException(
+          `Panelists with IDs ${missingIds.join(', ')} not found`,
+        );
       }
       // Store complete panelist objects for fast access
       completePanelists = panelists;
@@ -204,15 +245,22 @@ export class WeeklyOverridesService {
     let completeChannel: any = null;
     if (dto.overrideType === 'create' && dto.specialProgram?.channelId) {
       const channelIdsArray = [dto.specialProgram.channelId];
-      const placeholders = channelIdsArray.map((_, index) => `$${index + 1}`).join(',');
-      const channels = await this.dataSource.query(`
+      const placeholders = channelIdsArray
+        .map((_, index) => `$${index + 1}`)
+        .join(',');
+      const channels = await this.dataSource.query(
+        `
         SELECT id, name, handle, youtube_channel_id, logo_url, description, "order", is_visible
         FROM channel 
         WHERE id IN (${placeholders})
-      `, channelIdsArray);
-      
+      `,
+        channelIdsArray,
+      );
+
       if (channels.length === 0) {
-        throw new NotFoundException(`Channel with ID ${dto.specialProgram.channelId} not found`);
+        throw new NotFoundException(
+          `Channel with ID ${dto.specialProgram.channelId} not found`,
+        );
       }
       completeChannel = channels[0];
     }
@@ -234,9 +282,15 @@ export class WeeklyOverridesService {
     // Check if override already exists
     const existing = await this.getWeeklyOverride(overrideId);
     if (existing) {
-      const entityType = dto.overrideType === 'create' ? 'this special program' : 
-                        dto.programId ? `program ${dto.programId}` : `schedule ${dto.scheduleId}`;
-      throw new BadRequestException(`An override already exists for ${entityType} on ${dto.targetWeek} week`);
+      const entityType =
+        dto.overrideType === 'create'
+          ? 'this special program'
+          : dto.programId
+            ? `program ${dto.programId}`
+            : `schedule ${dto.scheduleId}`;
+      throw new BadRequestException(
+        `An override already exists for ${entityType} on ${dto.targetWeek} week`,
+      );
     }
 
     const override: WeeklyOverride = {
@@ -254,23 +308,31 @@ export class WeeklyOverridesService {
       createdAt: new Date(),
       panelistIds: dto.panelistIds, // Keep legacy field for backward compatibility
       panelists: completePanelists, // Always store complete objects (even if empty array)
-      specialProgram: dto.specialProgram ? {
-        ...dto.specialProgram,
-        channel: completeChannel, // Store complete channel object
-      } : undefined,
+      specialProgram: dto.specialProgram
+        ? {
+            ...dto.specialProgram,
+            channel: completeChannel, // Store complete channel object
+          }
+        : undefined,
     };
 
     // Store in Redis with expiration
-    const expirationDate = this.dayjs(expiresAt).tz('America/Argentina/Buenos_Aires');
+    const expirationDate = this.dayjs(expiresAt).tz(
+      'America/Argentina/Buenos_Aires',
+    );
     const secondsUntilExpiry = expirationDate.diff(now, 'seconds');
-    await this.redisService.set(`weekly_override:${overrideId}`, override, secondsUntilExpiry);
+    await this.redisService.set(
+      `weekly_override:${overrideId}`,
+      override,
+      secondsUntilExpiry,
+    );
 
     // Clear unified schedule cache
     await this.redisService.del('schedules:week:complete');
-    
+
     // Smart weekly cache update: update instead of invalidate
     await this.updateWeeklyCacheForWeek(weekStartDate);
-    
+
     // Warm cache asynchronously (non-blocking)
     this.schedulesService?.debouncedWarmSchedulesCache?.();
 
@@ -289,16 +351,23 @@ export class WeeklyOverridesService {
   /**
    * Update a weekly override
    */
-  async updateWeeklyOverride(overrideId: string, dto: Partial<WeeklyOverrideDto>): Promise<WeeklyOverride> {
+  async updateWeeklyOverride(
+    overrideId: string,
+    dto: Partial<WeeklyOverrideDto>,
+  ): Promise<WeeklyOverride> {
     // Get the existing override
     const existingOverride = await this.getWeeklyOverride(overrideId);
     if (!existingOverride) {
-      throw new NotFoundException(`Weekly override with ID ${overrideId} not found`);
+      throw new NotFoundException(
+        `Weekly override with ID ${overrideId} not found`,
+      );
     }
 
     // Validate that either scheduleId or programId is provided (but not both) if they're being updated
     if (dto.scheduleId && dto.programId) {
-      throw new BadRequestException('Cannot provide both scheduleId and programId. Use one or the other.');
+      throw new BadRequestException(
+        'Cannot provide both scheduleId and programId. Use one or the other.',
+      );
     }
 
     // Validate schedule exists (only for non-create overrides with scheduleId)
@@ -309,7 +378,9 @@ export class WeeklyOverridesService {
       });
 
       if (!schedule) {
-        throw new NotFoundException(`Schedule with ID ${dto.scheduleId} not found`);
+        throw new NotFoundException(
+          `Schedule with ID ${dto.scheduleId} not found`,
+        );
       }
     }
 
@@ -321,31 +392,46 @@ export class WeeklyOverridesService {
       });
 
       if (!program) {
-        throw new NotFoundException(`Program with ID ${dto.programId} not found`);
+        throw new NotFoundException(
+          `Program with ID ${dto.programId} not found`,
+        );
       }
     }
 
     // Validate special program data for create overrides
     if (dto.overrideType === 'create') {
       if (!dto.specialProgram) {
-        throw new BadRequestException('Special program data is required for create overrides');
+        throw new BadRequestException(
+          'Special program data is required for create overrides',
+        );
       }
       if (!dto.specialProgram.name || !dto.specialProgram.channelId) {
-        throw new BadRequestException('Special program name and channelId are required');
+        throw new BadRequestException(
+          'Special program name and channelId are required',
+        );
       }
       if (!dto.newStartTime || !dto.newEndTime || !dto.newDayOfWeek) {
-        throw new BadRequestException('Start time, end time, and day of week are required for create overrides');
+        throw new BadRequestException(
+          'Start time, end time, and day of week are required for create overrides',
+        );
       }
     }
 
     // Validate override type requirements
-    if ((dto.overrideType === 'time_change' || dto.overrideType === 'reschedule') && 
-        (!dto.newStartTime || !dto.newEndTime)) {
-      throw new BadRequestException('New start time and end time are required for time changes and reschedules');
+    if (
+      (dto.overrideType === 'time_change' ||
+        dto.overrideType === 'reschedule') &&
+      (!dto.newStartTime || !dto.newEndTime)
+    ) {
+      throw new BadRequestException(
+        'New start time and end time are required for time changes and reschedules',
+      );
     }
 
     if (dto.overrideType === 'reschedule' && !dto.newDayOfWeek) {
-      throw new BadRequestException('New day of week is required for reschedules');
+      throw new BadRequestException(
+        'New day of week is required for reschedules',
+      );
     }
 
     // Validate and fetch complete panelist objects if provided
@@ -355,9 +441,13 @@ export class WeeklyOverridesService {
         where: { id: In(dto.panelistIds) },
       });
       if (panelists.length !== dto.panelistIds.length) {
-        const foundIds = panelists.map(p => p.id);
-        const missingIds = dto.panelistIds.filter(id => !foundIds.includes(id));
-        throw new NotFoundException(`Panelists with IDs ${missingIds.join(', ')} not found`);
+        const foundIds = panelists.map((p) => p.id);
+        const missingIds = dto.panelistIds.filter(
+          (id) => !foundIds.includes(id),
+        );
+        throw new NotFoundException(
+          `Panelists with IDs ${missingIds.join(', ')} not found`,
+        );
       }
       // Store complete panelist objects for fast access
       completePanelists = panelists;
@@ -370,15 +460,22 @@ export class WeeklyOverridesService {
     let completeChannel: any = null;
     if (dto.overrideType === 'create' && dto.specialProgram?.channelId) {
       const channelIdsArray = [dto.specialProgram.channelId];
-      const placeholders = channelIdsArray.map((_, index) => `$${index + 1}`).join(',');
-      const channels = await this.dataSource.query(`
+      const placeholders = channelIdsArray
+        .map((_, index) => `$${index + 1}`)
+        .join(',');
+      const channels = await this.dataSource.query(
+        `
         SELECT id, name, handle, youtube_channel_id, logo_url, description, "order", is_visible
         FROM channel 
         WHERE id IN (${placeholders})
-      `, channelIdsArray);
-      
+      `,
+        channelIdsArray,
+      );
+
       if (channels.length === 0) {
-        throw new NotFoundException(`Channel with ID ${dto.specialProgram.channelId} not found`);
+        throw new NotFoundException(
+          `Channel with ID ${dto.specialProgram.channelId} not found`,
+        );
       }
       completeChannel = channels[0];
     } else if (existingOverride.specialProgram?.channel) {
@@ -397,13 +494,17 @@ export class WeeklyOverridesService {
       expiresAt: existingOverride.expiresAt,
       // Update complete objects
       panelists: completePanelists, // Always store complete objects (even if empty array)
-      specialProgram: dto.specialProgram ? {
-        ...dto.specialProgram,
-        channel: completeChannel,
-      } : existingOverride.specialProgram ? {
-        ...existingOverride.specialProgram,
-        channel: completeChannel,
-      } : undefined,
+      specialProgram: dto.specialProgram
+        ? {
+            ...dto.specialProgram,
+            channel: completeChannel,
+          }
+        : existingOverride.specialProgram
+          ? {
+              ...existingOverride.specialProgram,
+              channel: completeChannel,
+            }
+          : undefined,
     };
 
     // Save to Redis
@@ -412,10 +513,10 @@ export class WeeklyOverridesService {
 
     // Clear unified cache
     await this.redisService.del('schedules:week:complete');
-    
+
     // Smart weekly cache update: update instead of invalidate
     await this.updateWeeklyCacheForWeek(existingOverride.weekStartDate);
-    
+
     // Warm cache asynchronously (non-blocking)
     this.schedulesService?.debouncedWarmSchedulesCache?.();
 
@@ -435,7 +536,9 @@ export class WeeklyOverridesService {
    * Get a specific weekly override
    */
   async getWeeklyOverride(overrideId: string): Promise<WeeklyOverride | null> {
-    const override = await this.redisService.get<WeeklyOverride>(`weekly_override:${overrideId}`);
+    const override = await this.redisService.get<WeeklyOverride>(
+      `weekly_override:${overrideId}`,
+    );
     if (override) {
       // Migrate override to new structure if needed
       return await this.migrateOverrideToNewStructure(override);
@@ -446,48 +549,76 @@ export class WeeklyOverridesService {
   /**
    * Migrate an override from old structure to new structure
    */
-  private async migrateOverrideToNewStructure(override: WeeklyOverride): Promise<WeeklyOverride> {
+  private async migrateOverrideToNewStructure(
+    override: WeeklyOverride,
+  ): Promise<WeeklyOverride> {
     let needsMigration = false;
     const migratedOverride = { ...override };
 
     // Migrate panelists if we have panelistIds but no panelists
-    if (override.panelistIds && override.panelistIds.length > 0 && !override.panelists) {
-      this.logger.debug(`[OVERRIDE-MIGRATION] Migrating panelists for override ${override.id}`);
+    if (
+      override.panelistIds &&
+      override.panelistIds.length > 0 &&
+      !override.panelists
+    ) {
+      this.logger.debug(
+        `[OVERRIDE-MIGRATION] Migrating panelists for override ${override.id}`,
+      );
       try {
         const panelists = await this.panelistsRepository.find({
           where: { id: In(override.panelistIds) },
         });
         migratedOverride.panelists = panelists;
         needsMigration = true;
-        this.logger.debug(`[OVERRIDE-MIGRATION] Migrated ${panelists.length} panelists for override ${override.id}`);
+        this.logger.debug(
+          `[OVERRIDE-MIGRATION] Migrated ${panelists.length} panelists for override ${override.id}`,
+        );
       } catch (error) {
-        this.logger.error(`[OVERRIDE-MIGRATION] Failed to migrate panelists for override ${override.id}:`, error.message);
+        this.logger.error(
+          `[OVERRIDE-MIGRATION] Failed to migrate panelists for override ${override.id}:`,
+          error.message,
+        );
         // Keep original structure if migration fails
       }
     }
 
     // Migrate channel if we have channelId but no channel object
-    if (override.specialProgram?.channelId && !override.specialProgram?.channel) {
-      this.logger.debug(`[OVERRIDE-MIGRATION] Migrating channel for override ${override.id}`);
+    if (
+      override.specialProgram?.channelId &&
+      !override.specialProgram?.channel
+    ) {
+      this.logger.debug(
+        `[OVERRIDE-MIGRATION] Migrating channel for override ${override.id}`,
+      );
       try {
         const channelIdsArray = [override.specialProgram.channelId];
-        const placeholders = channelIdsArray.map((_, index) => `$${index + 1}`).join(',');
-        const channels = await this.dataSource.query(`
+        const placeholders = channelIdsArray
+          .map((_, index) => `$${index + 1}`)
+          .join(',');
+        const channels = await this.dataSource.query(
+          `
           SELECT id, name, handle, youtube_channel_id, logo_url, description, "order", is_visible
           FROM channel 
           WHERE id IN (${placeholders})
-        `, channelIdsArray);
-        
+        `,
+          channelIdsArray,
+        );
+
         if (channels.length > 0) {
           migratedOverride.specialProgram = {
             ...migratedOverride.specialProgram!,
             channel: channels[0],
           };
           needsMigration = true;
-          this.logger.debug(`[OVERRIDE-MIGRATION] Migrated channel for override ${override.id}`);
+          this.logger.debug(
+            `[OVERRIDE-MIGRATION] Migrated channel for override ${override.id}`,
+          );
         }
       } catch (error) {
-        this.logger.error(`[OVERRIDE-MIGRATION] Failed to migrate channel for override ${override.id}:`, error.message);
+        this.logger.error(
+          `[OVERRIDE-MIGRATION] Failed to migrate channel for override ${override.id}:`,
+          error.message,
+        );
         // Keep original structure if migration fails
       }
     }
@@ -497,16 +628,30 @@ export class WeeklyOverridesService {
       try {
         const key = `weekly_override:${override.id}`;
         // Calculate TTL based on expiration date
-        const expirationDate = this.dayjs(override.expiresAt).tz('America/Argentina/Buenos_Aires');
+        const expirationDate = this.dayjs(override.expiresAt).tz(
+          'America/Argentina/Buenos_Aires',
+        );
         const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
-        const secondsUntilExpiry = Math.max(0, expirationDate.diff(now, 'seconds'));
-        
+        const secondsUntilExpiry = Math.max(
+          0,
+          expirationDate.diff(now, 'seconds'),
+        );
+
         if (secondsUntilExpiry > 0) {
-          await this.redisService.set(key, migratedOverride, secondsUntilExpiry);
-          this.logger.debug(`[OVERRIDE-MIGRATION] Saved migrated override ${override.id} to cache`);
+          await this.redisService.set(
+            key,
+            migratedOverride,
+            secondsUntilExpiry,
+          );
+          this.logger.debug(
+            `[OVERRIDE-MIGRATION] Saved migrated override ${override.id} to cache`,
+          );
         }
       } catch (error) {
-        this.logger.error(`[OVERRIDE-MIGRATION] Failed to save migrated override ${override.id}:`, error.message);
+        this.logger.error(
+          `[OVERRIDE-MIGRATION] Failed to save migrated override ${override.id}:`,
+          error.message,
+        );
       }
     }
 
@@ -518,24 +663,32 @@ export class WeeklyOverridesService {
    */
   async getOverridesForWeek(weekStartDate: string): Promise<WeeklyOverride[]> {
     const cacheKey = `weekly_overrides:${weekStartDate}`;
-    
+
     // Try cache first
     const cached = await this.redisService.get<WeeklyOverride[]>(cacheKey);
     if (cached) {
-      this.logger.debug(`[OVERRIDES-CACHE] Cache hit for week ${weekStartDate}: ${cached.length} overrides`);
+      this.logger.debug(
+        `[OVERRIDES-CACHE] Cache hit for week ${weekStartDate}: ${cached.length} overrides`,
+      );
       return cached;
     }
 
-    this.logger.debug(`[OVERRIDES-CACHE] Cache miss for week ${weekStartDate}, fetching from individual caches`);
-    
+    this.logger.debug(
+      `[OVERRIDES-CACHE] Cache miss for week ${weekStartDate}, fetching from individual caches`,
+    );
+
     // Fetch from individual caches (existing logic)
-    const overrides = await this.fetchOverridesFromIndividualCaches(weekStartDate);
+    const overrides =
+      await this.fetchOverridesFromIndividualCaches(weekStartDate);
 
     // Calculate smart TTL based on whether this is current week or next week
     const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
     const currentWeekStart = now.startOf('week').format('YYYY-MM-DD');
-    const nextWeekStart = now.add(1, 'week').startOf('week').format('YYYY-MM-DD');
-    
+    const nextWeekStart = now
+      .add(1, 'week')
+      .startOf('week')
+      .format('YYYY-MM-DD');
+
     let ttlSeconds: number;
     if (weekStartDate === currentWeekStart) {
       // Current week overrides expire at end of current week
@@ -552,8 +705,10 @@ export class WeeklyOverridesService {
 
     // Cache the combined result with smart TTL
     await this.redisService.set(cacheKey, overrides, ttlSeconds);
-    this.logger.debug(`[OVERRIDES-CACHE] Cached ${overrides.length} overrides for week ${weekStartDate} with TTL ${ttlSeconds}s`);
-    
+    this.logger.debug(
+      `[OVERRIDES-CACHE] Cached ${overrides.length} overrides for week ${weekStartDate} with TTL ${ttlSeconds}s`,
+    );
+
     return overrides;
   }
 
@@ -562,19 +717,26 @@ export class WeeklyOverridesService {
    */
   private async updateWeeklyCacheForWeek(weekStartDate: string): Promise<void> {
     const cacheKey = `weekly_overrides:${weekStartDate}`;
-    
+
     // Check if weekly cache exists
-    const existingCache = await this.redisService.get<WeeklyOverride[]>(cacheKey);
+    const existingCache =
+      await this.redisService.get<WeeklyOverride[]>(cacheKey);
     if (existingCache) {
       // Cache exists - update it by refetching from individual caches
-      this.logger.debug(`[OVERRIDES-CACHE] Updating existing cache for week ${weekStartDate}`);
-      const updatedOverrides = await this.fetchOverridesFromIndividualCaches(weekStartDate);
-      
+      this.logger.debug(
+        `[OVERRIDES-CACHE] Updating existing cache for week ${weekStartDate}`,
+      );
+      const updatedOverrides =
+        await this.fetchOverridesFromIndividualCaches(weekStartDate);
+
       // Calculate smart TTL
       const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
       const currentWeekStart = now.startOf('week').format('YYYY-MM-DD');
-      const nextWeekStart = now.add(1, 'week').startOf('week').format('YYYY-MM-DD');
-      
+      const nextWeekStart = now
+        .add(1, 'week')
+        .startOf('week')
+        .format('YYYY-MM-DD');
+
       let ttlSeconds: number;
       if (weekStartDate === currentWeekStart) {
         const weekEnd = now.endOf('week');
@@ -585,29 +747,37 @@ export class WeeklyOverridesService {
       } else {
         ttlSeconds = 7 * 24 * 60 * 60;
       }
-      
+
       // Update the cache
       await this.redisService.set(cacheKey, updatedOverrides, ttlSeconds);
-      this.logger.debug(`[OVERRIDES-CACHE] Updated cache for week ${weekStartDate} with ${updatedOverrides.length} overrides, TTL ${ttlSeconds}s`);
+      this.logger.debug(
+        `[OVERRIDES-CACHE] Updated cache for week ${weekStartDate} with ${updatedOverrides.length} overrides, TTL ${ttlSeconds}s`,
+      );
     } else {
       // Cache doesn't exist - just delete the key to be safe
       await this.redisService.del(cacheKey);
-      this.logger.debug(`[OVERRIDES-CACHE] No existing cache for week ${weekStartDate}, cleared key`);
+      this.logger.debug(
+        `[OVERRIDES-CACHE] No existing cache for week ${weekStartDate}, cleared key`,
+      );
     }
   }
 
   /**
    * Fetch overrides from individual caches (original logic)
    */
-  private async fetchOverridesFromIndividualCaches(weekStartDate: string): Promise<WeeklyOverride[]> {
+  private async fetchOverridesFromIndividualCaches(
+    weekStartDate: string,
+  ): Promise<WeeklyOverride[]> {
     // Use a more specific Redis key pattern for the target week
     // This pattern will match: schedule_123_2024-01-01, program_456_2024-01-01, special_program_name_2024-01-01
     const weekPattern = `weekly_override:*_${weekStartDate}`;
     const overrides: WeeklyOverride[] = [];
-    
+
     // Use Redis SCAN to find matching keys
-    const stream = (this.redisService as any).client.scanStream({ match: weekPattern });
-    
+    const stream = (this.redisService as any).client.scanStream({
+      match: weekPattern,
+    });
+
     const keys: string[] = [];
     for await (const keyChunk of stream) {
       keys.push(...keyChunk);
@@ -616,20 +786,25 @@ export class WeeklyOverridesService {
     // OPTIMIZATION: Use Redis pipeline to fetch all overrides in one round trip
     if (keys.length > 0) {
       const pipeline = (this.redisService as any).client.pipeline();
-      keys.forEach(key => pipeline.get(key));
+      keys.forEach((key) => pipeline.get(key));
       const results = await pipeline.exec();
-      
+
       // Process pipeline results and migrate if needed
       for (let i = 0; i < results.length; i++) {
         const result = results[i];
-        if (result[0] === null && result[1]) { // No error and has data
+        if (result[0] === null && result[1]) {
+          // No error and has data
           try {
             const override = JSON.parse(result[1]);
             // Migrate override to new structure if needed
-            const migratedOverride = await this.migrateOverrideToNewStructure(override);
+            const migratedOverride =
+              await this.migrateOverrideToNewStructure(override);
             overrides.push(migratedOverride);
           } catch (error) {
-            this.logger.warn(`[WEEKLY-OVERRIDES] Failed to parse override ${keys[i]}:`, error);
+            this.logger.warn(
+              `[WEEKLY-OVERRIDES] Failed to parse override ${keys[i]}:`,
+              error,
+            );
           }
         }
       }
@@ -647,7 +822,10 @@ export class WeeklyOverridesService {
   }> {
     const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
     const currentWeekStart = now.startOf('week').format('YYYY-MM-DD');
-    const nextWeekStart = now.add(1, 'week').startOf('week').format('YYYY-MM-DD');
+    const nextWeekStart = now
+      .add(1, 'week')
+      .startOf('week')
+      .format('YYYY-MM-DD');
 
     const [currentWeek, nextWeek] = await Promise.all([
       this.getOverridesForWeek(currentWeekStart),
@@ -666,14 +844,17 @@ export class WeeklyOverridesService {
       return false;
     }
 
-    await this.redisService.del([`weekly_override:${overrideId}`, 'schedules:week:complete']);
+    await this.redisService.del([
+      `weekly_override:${overrideId}`,
+      'schedules:week:complete',
+    ]);
 
     // Smart weekly cache update: update instead of invalidate
     await this.updateWeeklyCacheForWeek(exists.weekStartDate);
-    
+
     // Warm cache asynchronously (non-blocking)
     this.schedulesService?.debouncedWarmSchedulesCache?.();
-    
+
     // Notify frontend via SSE
     await this.notifyUtil.notifyAndRevalidate({
       eventType: 'override_deleted',
@@ -682,38 +863,49 @@ export class WeeklyOverridesService {
       payload: {},
       revalidatePaths: ['/'],
     });
-    
+
     return true;
   }
 
   /**
    * Apply weekly overrides to schedules for a specific week
    */
-  async applyWeeklyOverrides(schedules: Schedule[], weekStartDate: string): Promise<Schedule[]> {
+  async applyWeeklyOverrides(
+    schedules: Schedule[],
+    weekStartDate: string,
+  ): Promise<Schedule[]> {
     const start = Date.now();
-    this.logger.debug(`START for week ${weekStartDate} with ${schedules.length} schedules`);
+    this.logger.debug(
+      `START for week ${weekStartDate} with ${schedules.length} schedules`,
+    );
     const overrides = await this.getOverridesForWeek(weekStartDate);
-    
+
     if (overrides.length === 0) {
       this.logger.debug(`No overrides. Completed in ${Date.now() - start}ms`);
       return schedules;
     }
 
     // Separate different types of overrides
-    const scheduleOverrides = overrides.filter(o => o.overrideType !== 'create' && o.scheduleId);
-    const programOverrides = overrides.filter(o => o.overrideType !== 'create' && o.programId);
-    const createOverrides = overrides.filter(o => o.overrideType === 'create');
+    const scheduleOverrides = overrides.filter(
+      (o) => o.overrideType !== 'create' && o.scheduleId,
+    );
+    const programOverrides = overrides.filter(
+      (o) => o.overrideType !== 'create' && o.programId,
+    );
+    const createOverrides = overrides.filter(
+      (o) => o.overrideType === 'create',
+    );
 
     // Create override maps
     const scheduleOverrideMap = new Map<number, WeeklyOverride>();
-    scheduleOverrides.forEach(override => {
+    scheduleOverrides.forEach((override) => {
       if (override.scheduleId) {
         scheduleOverrideMap.set(override.scheduleId, override);
       }
     });
 
     const programOverrideMap = new Map<number, WeeklyOverride>();
-    programOverrides.forEach(override => {
+    programOverrides.forEach((override) => {
       if (override.programId) {
         programOverrideMap.set(override.programId, override);
       }
@@ -733,7 +925,10 @@ export class WeeklyOverridesService {
     const channelsMap = new Map<number, any>();
     for (const override of overrides) {
       if (override.specialProgram?.channel) {
-        channelsMap.set(override.specialProgram.channel.id, override.specialProgram.channel);
+        channelsMap.set(
+          override.specialProgram.channel.id,
+          override.specialProgram.channel,
+        );
       }
     }
 
@@ -742,8 +937,10 @@ export class WeeklyOverridesService {
     // Apply overrides to schedules
     for (const schedule of schedules) {
       // Check if the schedule's program has a program-level override
-      const programOverride = schedule.program ? programOverrideMap.get(schedule.program.id) : null;
-      
+      const programOverride = schedule.program
+        ? programOverrideMap.get(schedule.program.id)
+        : null;
+
       if (programOverride) {
         // Handle program-level override
         switch (programOverride.overrideType) {
@@ -759,15 +956,18 @@ export class WeeklyOverridesService {
               isWeeklyOverride: true,
               overrideType: programOverride.overrideType,
             } as any;
-            
+
             // Add panelists if specified in the override
-            if (programOverride.panelists && programOverride.panelists.length > 0) {
+            if (
+              programOverride.panelists &&
+              programOverride.panelists.length > 0
+            ) {
               modifiedSchedule1.program = {
                 ...modifiedSchedule1.program,
                 panelists: programOverride.panelists,
               };
             }
-            
+
             modifiedSchedules.push(modifiedSchedule1);
             break;
           case 'reschedule':
@@ -780,15 +980,18 @@ export class WeeklyOverridesService {
               isWeeklyOverride: true,
               overrideType: programOverride.overrideType,
             } as any;
-            
+
             // Add panelists if specified in the override
-            if (programOverride.panelists && programOverride.panelists.length > 0) {
+            if (
+              programOverride.panelists &&
+              programOverride.panelists.length > 0
+            ) {
               modifiedSchedule2.program = {
                 ...modifiedSchedule2.program,
                 panelists: programOverride.panelists,
               };
             }
-            
+
             modifiedSchedules.push(modifiedSchedule2);
             break;
           default:
@@ -799,7 +1002,7 @@ export class WeeklyOverridesService {
 
       // Check for schedule-specific override
       const scheduleOverride = scheduleOverrideMap.get(schedule.id);
-      
+
       if (!scheduleOverride) {
         modifiedSchedules.push(schedule);
         continue;
@@ -818,15 +1021,18 @@ export class WeeklyOverridesService {
             isWeeklyOverride: true,
             overrideType: scheduleOverride.overrideType,
           } as any;
-          
+
           // Add panelists if specified in the override
-          if (scheduleOverride.panelists && scheduleOverride.panelists.length > 0) {
+          if (
+            scheduleOverride.panelists &&
+            scheduleOverride.panelists.length > 0
+          ) {
             modifiedSchedule3.program = {
               ...modifiedSchedule3.program,
               panelists: scheduleOverride.panelists,
             };
           }
-          
+
           modifiedSchedules.push(modifiedSchedule3);
           break;
 
@@ -839,15 +1045,18 @@ export class WeeklyOverridesService {
             isWeeklyOverride: true,
             overrideType: scheduleOverride.overrideType,
           } as any;
-          
+
           // Add panelists if specified in the override
-          if (scheduleOverride.panelists && scheduleOverride.panelists.length > 0) {
+          if (
+            scheduleOverride.panelists &&
+            scheduleOverride.panelists.length > 0
+          ) {
             modifiedSchedule4.program = {
               ...modifiedSchedule4.program,
               panelists: scheduleOverride.panelists,
             };
           }
-          
+
           modifiedSchedules.push(modifiedSchedule4);
           break;
 
@@ -858,8 +1067,15 @@ export class WeeklyOverridesService {
 
     // Add virtual schedules for create overrides
     for (const override of createOverrides) {
-      if (override.specialProgram && override.newStartTime && override.newEndTime && override.newDayOfWeek) {
-        const channel = override.specialProgram.channel || channelsMap.get(override.specialProgram.channelId);
+      if (
+        override.specialProgram &&
+        override.newStartTime &&
+        override.newEndTime &&
+        override.newDayOfWeek
+      ) {
+        const channel =
+          override.specialProgram.channel ||
+          channelsMap.get(override.specialProgram.channelId);
         const virtualSchedule: any = {
           id: `virtual_${override.id}`,
           day_of_week: override.newDayOfWeek,
@@ -873,18 +1089,20 @@ export class WeeklyOverridesService {
             description: override.specialProgram.description || '',
             logo_url: override.specialProgram.imageUrl || '',
             stream_url: override.specialProgram.stream_url || null,
-            channel: channel ? {
-              id: channel.id,
-              name: channel.name,
-              handle: channel.handle,
-              youtube_channel_id: channel.youtube_channel_id,
-              logo_url: channel.logo_url,
-              description: channel.description,
-              order: channel.order,
-            } : {
-              id: override.specialProgram.channelId,
-              name: 'Special Program', // Fallback if channel not found
-            },
+            channel: channel
+              ? {
+                  id: channel.id,
+                  name: channel.name,
+                  handle: channel.handle,
+                  youtube_channel_id: channel.youtube_channel_id,
+                  logo_url: channel.logo_url,
+                  description: channel.description,
+                  order: channel.order,
+                }
+              : {
+                  id: override.specialProgram.channelId,
+                  name: 'Special Program', // Fallback if channel not found
+                },
             // Add panelists if specified in the override
             panelists: override.panelists || [],
           },
@@ -901,7 +1119,7 @@ export class WeeklyOverridesService {
    */
   getWeekStartDate(targetWeek: 'current' | 'next'): string {
     const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
-    
+
     if (targetWeek === 'current') {
       return now.startOf('week').format('YYYY-MM-DD');
     } else {
@@ -915,10 +1133,12 @@ export class WeeklyOverridesService {
   async cleanupExpiredOverrides(): Promise<number> {
     const pattern = 'weekly_override:*';
     const overrides: WeeklyOverride[] = [];
-    
+
     // Use Redis SCAN to find all weekly override keys
-    const stream = (this.redisService as any).client.scanStream({ match: pattern });
-    
+    const stream = (this.redisService as any).client.scanStream({
+      match: pattern,
+    });
+
     const keys: string[] = [];
     for await (const keyChunk of stream) {
       keys.push(...keyChunk);
@@ -931,35 +1151,47 @@ export class WeeklyOverridesService {
     // OPTIMIZATION: Use Redis pipeline to fetch all overrides in one round trip
     if (keys.length > 0) {
       const pipeline = (this.redisService as any).client.pipeline();
-      keys.forEach(key => pipeline.get(key));
+      keys.forEach((key) => pipeline.get(key));
       const results = await pipeline.exec();
-      
+
       const expiredKeys: string[] = [];
-      
+
       // Process pipeline results
       results.forEach((result, index) => {
-        if (result[0] === null && result[1]) { // No error and has data
+        if (result[0] === null && result[1]) {
+          // No error and has data
           try {
             const override = JSON.parse(result[1]);
-            if (override && this.dayjs(override.expiresAt).tz('America/Argentina/Buenos_Aires').isBefore(now)) {
+            if (
+              override &&
+              this.dayjs(override.expiresAt)
+                .tz('America/Argentina/Buenos_Aires')
+                .isBefore(now)
+            ) {
               expiredKeys.push(keys[index]);
             }
           } catch (error) {
-            this.logger.warn(`[WEEKLY-OVERRIDES] Failed to parse override ${keys[index]} for cleanup:`, error);
+            this.logger.warn(
+              `[WEEKLY-OVERRIDES] Failed to parse override ${keys[index]} for cleanup:`,
+              error,
+            );
           }
         }
       });
-      
+
       // Delete expired overrides
-      for (const key of expiredKeys) {
-        await this.redisService.del(key);
-        cleaned++;
+      if (expiredKeys.length > 0) {
+        const CHUNK_SIZE = 500;
+        for (let i = 0; i < expiredKeys.length; i += CHUNK_SIZE) {
+          await this.redisService.del(expiredKeys.slice(i, i + CHUNK_SIZE));
+        }
+        cleaned = expiredKeys.length;
       }
     }
 
     if (cleaned > 0) {
       await this.redisService.del('schedules:week:complete');
-      
+
       // Warm cache asynchronously (non-blocking)
       this.schedulesService?.debouncedWarmSchedulesCache?.();
     }
@@ -970,31 +1202,57 @@ export class WeeklyOverridesService {
   /**
    * Delete all weekly overrides for a given program and its schedules
    */
-  async deleteOverridesForProgram(programId: number, scheduleIds: number[]): Promise<number> {
+  async deleteOverridesForProgram(
+    programId: number,
+    scheduleIds: number[],
+  ): Promise<number> {
     const pattern = 'weekly_override:*';
-    const stream = (this.redisService as any).client.scanStream({ match: pattern });
+    const stream = (this.redisService as any).client.scanStream({
+      match: pattern,
+    });
     const keys: string[] = [];
     for await (const keyChunk of stream) {
       keys.push(...keyChunk);
     }
+
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+    if (keys.length > 0) {
+      const keysToDelete: string[] = [];
+      const CHUNK_SIZE = 500;
+
+      for (let i = 0; i < keys.length; i += CHUNK_SIZE) {
+        const chunkKeys = keys.slice(i, i + CHUNK_SIZE);
+        const overrides =
+          await this.redisService.mget<WeeklyOverride>(chunkKeys);
+
+        for (let j = 0; j < chunkKeys.length; j++) {
+          const override = overrides[j];
+          if (!override) continue;
+
+          if (
+            (override.programId && override.programId === programId) ||
+            (override.scheduleId && scheduleIds.includes(override.scheduleId))
+          ) {
+            keysToDelete.push(chunkKeys[j]);
+          }
+        }
+      }
+
+      if (keysToDelete.length > 0) {
+        // Delete in batches to avoid overwhelming Redis
+        for (let i = 0; i < keysToDelete.length; i += CHUNK_SIZE) {
+          await this.redisService.del(keysToDelete.slice(i, i + CHUNK_SIZE));
+        }
+        deleted = keysToDelete.length;
       }
     }
+
     if (deleted > 0) {
       await this.redisService.del('schedules:week:complete');
-      
+
       // Warm cache asynchronously (non-blocking)
       this.schedulesService?.debouncedWarmSchedulesCache?.();
-      
+
       // Notify frontend via SSE
       await this.notifyUtil.notifyAndRevalidate({
         eventType: 'overrides_bulk_deleted',
@@ -1006,4 +1264,4 @@ export class WeeklyOverridesService {
     }
     return deleted;
   }
-} 
+}


### PR DESCRIPTION
💡 What: Refactored `cleanupExpiredOverrides` and `deleteOverridesForProgram` in `src/schedules/weekly-overrides.service.ts` to use Redis batch operations (`mget` and `del([keys])`) instead of individual loop-based operations. Added chunking (500 items/chunk) to prevent memory and network limits.
🎯 Why: Both functions were iterating over hundreds of Redis keys and issuing individual `get` and `del` commands to the Redis instance, resulting in O(N) network overhead (an N+1 query problem) which drastically increases response latency and Redis load.
📊 Impact: Reduces the number of Redis round-trips from O(N) to O(N/500). For 1000 items, this converts 1000 individual queries into 2 queries, theoretically reducing the network latency portion of these functions by up to 99%.
🔬 Measurement: Verify cache cleanup execution times remain low (e.g., less than 50ms) even with thousands of weekly overrides present in Redis.

---
*PR created automatically by Jules for task [9873020475878971354](https://jules.google.com/task/9873020475878971354) started by @matiasrozenblum*