### PR TITLE
⚡ Bolt: [performance improvement] Eliminate N+1 Redis Query network roundtrips during cache invalidation loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2024-11-20 - [Redis Batch Deletion]
+**Learning:** I noticed sequential `await RedisService.del(key)` operations being used within loops (e.g. iterating over scan stream results or filtering expired keys), which leads to an N+1 network round-trip penalty to the Redis server.
+**Action:** Replace `for` loops containing `await redisService.del(key)` or `await redisService.get(key)` with batched `mget` array fetches and batched `del` array operations. Redis strongly supports these array-based parameters, efficiently completing multiple actions in a single network trip. Always use these batch equivalents where possible.

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -33,6 +33,7 @@ describe('WeeklyOverridesService', () => {
 
   const mockRedisService = {
     get: jest.fn(),
+    mget: jest.fn(),
     set: jest.fn(),
     del: jest.fn(),
     delByPattern: jest.fn(),

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1179,10 +1179,10 @@ export class WeeklyOverridesService {
         }
       });
 
-      // Delete expired overrides
-      for (const key of expiredKeys) {
-        await this.redisService.del(key);
-        cleaned++;
+      // OPTIMIZATION: Use batch deletion to avoid N+1 Redis network round-trips
+      if (expiredKeys.length > 0) {
+        await this.redisService.del(expiredKeys);
+        cleaned += expiredKeys.length;
       }
     }
 
@@ -1212,15 +1212,25 @@ export class WeeklyOverridesService {
       keys.push(...keyChunk);
     }
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+
+    // OPTIMIZATION: Use mget and batch deletion to eliminate N+1 Redis network queries
+    if (keys.length > 0) {
+      const overrides = await this.redisService.mget<WeeklyOverride>(keys);
+      const keysToDelete: string[] = [];
+
+      overrides.forEach((override, index) => {
+        if (!override) return;
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          keysToDelete.push(keys[index]);
+        }
+      });
+
+      if (keysToDelete.length > 0) {
+        await this.redisService.del(keysToDelete);
+        deleted = keysToDelete.length;
       }
     }
     if (deleted > 0) {


### PR DESCRIPTION
💡 **What:** Replaced sequential `await redisService.del(key)` operations inside loop statements in `src/schedules/weekly-overrides.service.ts` with batched `mget` arrays and grouped `del(keysToDelete)` arrays.\n\n🎯 **Why:** To eliminate the N+1 network round-trip overhead imposed by iterating through multiple individual keys and issuing separate `GET` and `DEL` commands to the Redis database.\n\n📊 **Impact:** Substantially decreases cache clearance latency. For $N$ expired override keys or scheduled program caches needing invalidation, the number of database/network requests executed is slashed from $O(N)$ to $O(1)$. \n\n🔬 **Measurement:** This was strictly verified via an isolated simulation model mapping loop latency to batched latency, confirming the equivalent operational side-effects with a reduction from $N$ `del` calls to precisely $1$ `del` call.\n\nCloses \#performance-optimization

---
*PR created automatically by Jules for task [10966160557333507727](https://jules.google.com/task/10966160557333507727) started by @matiasrozenblum*