### PR TITLE
⚡ Bolt: [performance improvement] batch Redis requests using mget in YoutubeLiveService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2024-05-24 - Redis MGET Batching for YoutubeLiveService
+
+**Learning:** When retrieving multiple sets of tracking data for channels from Redis inside loops (e.g. `getBatchLiveStreams`), sequential `.get` calls heavily impact overall response times due to N+1 query latency.
+**Action:** Use `Array.map` to generate arrays of keys based on channel handles before the loop, and use `Promise.all` with `RedisService.mget` to perform batch lookups, ensuring we maintain exact caching/escalation state by using the array index inside the iteration.

--- a/src/youtube/youtube-live.service.spec.ts
+++ b/src/youtube/youtube-live.service.spec.ts
@@ -1128,9 +1128,11 @@ describe('YoutubeLiveService', () => {
 
     describe('getBatchLiveStreams - Escalation Logic', () => {
       it('skips channels with active not-found flags', async () => {
-        redisService.get.mockImplementation(async (key: string) => {
-          if (key === 'videoIdNotFound:handle') return '1';
-          return null;
+        redisService.mget.mockImplementation(async (keys: string[]) => {
+          return keys.map((key) => {
+            if (key === 'videoIdNotFound:handle') return '1';
+            return null;
+          });
         });
 
         const result = await (service as any).getBatchLiveStreams(

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -321,13 +321,29 @@ export class YoutubeLiveService {
     this.logger.debug(
       `Fetching live streams for ${channelIds.length} channels`,
     );
-
     // First, check cache for each channel and collect channels that need fresh fetching
     const channelsToFetch: string[] = [];
     const channelHandles = new Map<string, string>(); // Map channelId to handle for logging
 
-    for (const channelId of channelIds) {
-      const handle = channelHandleMap?.get(channelId) || 'unknown';
+    const handles = channelIds.map(
+      (id) => channelHandleMap?.get(id) || 'unknown',
+    );
+
+    // Pre-fetch all Redis keys in batches to avoid N+1 queries
+    const notFoundKeys = handles.map((h) => `videoIdNotFound:${h}`);
+    const attemptTrackingKeys = handles.map((h) => `notFoundAttempts:${h}`);
+    const statusCacheKeys = handles.map((h) => `liveStatusByHandle:${h}`);
+
+    const [notFoundResults, attemptResults, statusCacheResults] =
+      await Promise.all([
+        this.redisService.mget<string>(notFoundKeys),
+        this.redisService.mget<AttemptTracking>(attemptTrackingKeys),
+        this.redisService.mget<LiveStatusCache>(statusCacheKeys),
+      ]);
+
+    for (let i = 0; i < channelIds.length; i++) {
+      const channelId = channelIds[i];
+      const handle = handles[i];
       channelHandles.set(channelId, handle);
 
       // Unified cache - use liveStatusByHandle (replaces liveStreamsByChannel)
@@ -336,9 +352,8 @@ export class YoutubeLiveService {
       const attemptTrackingKey = `notFoundAttempts:${handle}`;
 
       // Enhanced not-found logic with escalation detection
-      const notFoundData = await this.redisService.get<string>(notFoundKey);
-      const attemptData =
-        await this.redisService.get<AttemptTracking>(attemptTrackingKey);
+      const notFoundData = notFoundResults[i];
+      const attemptData = attemptResults[i];
 
       if (
         notFoundData &&
@@ -447,8 +462,7 @@ export class YoutubeLiveService {
       }
 
       // Check unified cache
-      const cachedStatus =
-        await this.redisService.get<LiveStatusCache>(statusCacheKey);
+      const cachedStatus = statusCacheResults[i];
       if (cachedStatus) {
         try {
           // Skip validation during bulk operations to improve performance for onDemand context


### PR DESCRIPTION
💡 What: Refactored `YoutubeLiveService.getBatchLiveStreams` to extract `videoIdNotFound`, `notFoundAttempts`, and `liveStatusByHandle` cache lookups into bulk `this.redisService.mget` calls wrapped in a single `Promise.all` before iterating over `channelIds`.

🎯 Why: The previous implementation performed three sequential `this.redisService.get` calls per channel within the iteration block, leading to an N+1 query problem and elevated Redis network overhead when checking large channel sets.

📊 Impact: Massively reduces Redis network latency per API request for YouTube channel syncs by decreasing the operation count from $O(3N)$ individual requests to exactly $O(3)$ batched requests.

🔬 Measurement: Local test simulation scripts assert valid structure mappings via concurrent `mget` requests. Lookups successfully map back based on correct index usage in the original iteration sequence. Evaluated with Jest.

---
*PR created automatically by Jules for task [6498102057701412676](https://jules.google.com/task/6498102057701412676) started by @matiasrozenblum*