### PR TITLE
⚡ Bolt: [performance improvement] Webhook Kick Subscription Verification Concurrency

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-04-10 - [N+1 Network Query Avoidance in Webhook Subscription Verification]
+**Learning:** Found N+1 network query patterns inside the `verifyKickSubscriptions` method of `WebhookSubscriptionService`. For every stored subscription key, it executed `await this.getKickSubscriptions(userId)` sequentially within a loop. This leads to extremely slow performance when there are many Kick subscriptions.
+**Action:** Replace the sequential `for` loop with `Promise.all` containing an inner `map` loop for concurrency. Ensure each concurrent task uses a `try-catch` block to prevent individual failures from terminating the whole batch.

--- a/src/webhooks/webhook-subscription.service.ts
+++ b/src/webhooks/webhook-subscription.service.ts
@@ -736,61 +736,77 @@ export class WebhookSubscriptionService {
       // Batch fetch all stored subscription data in a single Redis call
       const storedDataBatch = await this.redisService.mget<any>(keys);
 
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
-        try {
-          // Extract username from key: webhook:subscription:kick:username
-          const username = key.replace(`${this.SUBSCRIPTION_PREFIX}kick:`, '');
+      // Group keys into batches to avoid rate limiting while still benefiting from concurrency
+      const BATCH_SIZE = 5;
+      for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+        const batchKeys = keys.slice(i, i + BATCH_SIZE);
+        const batchIndices = Array.from(
+          { length: batchKeys.length },
+          (_, idx) => i + idx,
+        );
 
-          // Get stored data from batch
-          const storedData = storedDataBatch[i];
-          const userId = storedData?.userId;
-
-          if (!userId) {
-            this.logger.warn(
-              `⚠️ No userId stored for ${username}, skipping verification`,
-            );
-            continue;
-          }
-
-          // Check with Kick API
-          const apiSubscriptions = await this.getKickSubscriptions(userId);
-          const hasActiveSubscription = apiSubscriptions.some(
-            (sub) => sub.event === 'livestream.status.updated',
-          );
-
-          if (hasActiveSubscription) {
-            active++;
-          } else {
-            // Subscription is not active - renew it
-            this.logger.warn(
-              `⚠️ Subscription for ${username} is NOT active - renewing...`,
-            );
-            const newSubId = await this.subscribeToKickWebhook(
-              username,
-              userId,
-            );
-            if (newSubId) {
-              renewed++;
-              this.logger.log(
-                `✅ Renewed subscription for ${username}: ${newSubId}`,
+        await Promise.all(
+          batchIndices.map(async (idx) => {
+            const key = keys[idx];
+            try {
+              // Extract username from key: webhook:subscription:kick:username
+              const username = key.replace(
+                `${this.SUBSCRIPTION_PREFIX}kick:`,
+                '',
               );
-            } else {
+
+              // Get stored data from batch
+              const storedData = storedDataBatch[idx];
+              const userId = storedData?.userId;
+
+              if (!userId) {
+                this.logger.warn(
+                  `⚠️ No userId stored for ${username}, skipping verification`,
+                );
+                return;
+              }
+
+              // Check with Kick API
+              const apiSubscriptions = await this.getKickSubscriptions(userId);
+              const hasActiveSubscription = apiSubscriptions.some(
+                (sub) => sub.event === 'livestream.status.updated',
+              );
+
+              if (hasActiveSubscription) {
+                active++;
+              } else {
+                // Subscription is not active - renew it
+                this.logger.warn(
+                  `⚠️ Subscription for ${username} is NOT active - renewing...`,
+                );
+                const newSubId = await this.subscribeToKickWebhook(
+                  username,
+                  userId,
+                );
+                if (newSubId) {
+                  renewed++;
+                  this.logger.log(
+                    `✅ Renewed subscription for ${username}: ${newSubId}`,
+                  );
+                } else {
+                  failed++;
+                  this.logger.error(
+                    `❌ Failed to renew subscription for ${username}`,
+                  );
+                }
+              }
+            } catch (error: any) {
               failed++;
               this.logger.error(
-                `❌ Failed to renew subscription for ${username}`,
+                `❌ Error checking subscription for key ${key}: ${error.message}`,
               );
             }
-          }
+          }),
+        );
 
-          // Small delay to avoid rate limiting
+        // Small delay between batches to avoid rate limiting
+        if (i + BATCH_SIZE < keys.length) {
           await new Promise((resolve) => setTimeout(resolve, 500));
-        } catch (error: any) {
-          failed++;
-          this.logger.error(
-            `❌ Error checking subscription for key ${key}:`,
-            error.message,
-          );
         }
       }
 


### PR DESCRIPTION
💡 **What:** Refactored `WebhookSubscriptionService.verifyKickSubscriptions` to verify Kick subscriptions concurrently in controlled batches of 5.
🎯 **Why:** Previously, the service verified active webhook subscriptions sequentially using a `for` loop, awaiting the `getKickSubscriptions` API check and optional renewal process for every individual user sequentially. This creates an N+1 query pattern leading to massive performance degradation and bottlenecking when iterating over dozens or hundreds of subscriptions.
📊 **Impact:** Reduces verification execution time dramatically by parallelizing the Kick API calls while respecting rate limits (via batching & 500ms sleep intervals).
🔬 **Measurement:** Execute `verifyKickSubscriptions` locally via a simulated trigger. Monitor standard output for `🔄 Kick subscription renewal complete: ...` and observe the reduced elapsed time compared to sequential execution. Tests have been run via `npm test` and formatting applied.

---
*PR created automatically by Jules for task [16030290342815982791](https://jules.google.com/task/16030290342815982791) started by @matiasrozenblum*