### PR TITLE
Release 1.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.26.1] - 2026-05-30
+
+### Fixed
+- Banner mutations (`create`, `update`, `remove`, `reorder`) now call `revalidateTags: ['banners']` instead of `revalidatePaths: ['/']`, preventing unnecessary invalidation of unrelated caches (schedules, categories, etc.)
+- `NotifyAndRevalidateUtil` extended to accept `revalidateTags` option and send `{ tag, secret }` body to the revalidation endpoint
+
+---
+
 ## [1.26.0] - 2026-05-24
 
 ### Added

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -262,7 +262,7 @@ export class BannersService {
       entity: 'banner',
       entityId: saved.id,
       payload: { banner: saved },
-      revalidatePaths: ['/'],
+      revalidateTags: ['banners'],
     });
 
     return saved;
@@ -344,7 +344,7 @@ export class BannersService {
       entity: 'banner',
       entityId: id,
       payload: { banner: updated },
-      revalidatePaths: ['/'],
+      revalidateTags: ['banners'],
     });
 
     return updated;
@@ -363,7 +363,7 @@ export class BannersService {
       entity: 'banner',
       entityId: id,
       payload: {},
-      revalidatePaths: ['/'],
+      revalidateTags: ['banners'],
     });
   }
 
@@ -398,7 +398,7 @@ export class BannersService {
       entity: 'banner',
       entityId: 'all',
       payload: { bannerIds: banners.map((b) => b.id) },
-      revalidatePaths: ['/'],
+      revalidateTags: ['banners'],
     });
 
     // Return updated banners in order

--- a/src/utils/notify-and-revalidate.util.spec.ts
+++ b/src/utils/notify-and-revalidate.util.spec.ts
@@ -15,7 +15,7 @@ describe('NotifyAndRevalidateUtil', () => {
     jest.clearAllMocks();
     global.fetch = jest
       .fn()
-      .mockResolvedValue({ status: 200, text: async () => 'ok' });
+      .mockResolvedValue({ ok: true, status: 200, text: async () => 'ok' });
     util = new NotifyAndRevalidateUtil(
       mockRedisService as any,
       frontendUrl,
@@ -69,6 +69,29 @@ describe('NotifyAndRevalidateUtil', () => {
           'x-vercel-protection-bypass': revalidateSecret,
         },
         body: JSON.stringify({ path: '/bar', secret: revalidateSecret }),
+      }),
+    );
+  });
+
+  it('calls the revalidation endpoint with tag param when revalidateTags is provided', async () => {
+    await util.notifyAndRevalidate({
+      eventType: 'test_event',
+      entity: 'test_entity',
+      entityId: 123,
+      payload: {},
+      revalidateTags: ['banners'],
+    });
+    await new Promise((resolve) => process.nextTick(resolve));
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://frontend.test/api/revalidate?x-vercel-set-bypass-cookie=true&x-vercel-protection-bypass=testsecret',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-vercel-protection-bypass': revalidateSecret,
+        },
+        body: JSON.stringify({ tag: 'banners', secret: revalidateSecret }),
       }),
     );
   });

--- a/src/utils/notify-and-revalidate.util.ts
+++ b/src/utils/notify-and-revalidate.util.ts
@@ -6,6 +6,7 @@ interface NotifyAndRevalidateOptions {
   entityId: string | number;
   payload?: any;
   revalidatePaths?: string[];
+  revalidateTags?: string[];
 }
 
 export class NotifyAndRevalidateUtil {
@@ -33,19 +34,30 @@ export class NotifyAndRevalidateUtil {
       300, // 5 minutes TTL
     );
 
-    // 2. Revalidate Next.js paths in the background (non-blocking, fire-and-forget)
+    // 2. Revalidate Next.js paths/tags in the background (non-blocking, fire-and-forget)
     if (options.revalidatePaths && options.revalidatePaths.length > 0) {
-      this.revalidateInBackground(options.revalidatePaths);
+      this.revalidateInBackground({ paths: options.revalidatePaths });
+    }
+    if (options.revalidateTags && options.revalidateTags.length > 0) {
+      this.revalidateInBackground({ tags: options.revalidateTags });
     }
   }
 
-  private revalidateInBackground(paths: string[]) {
+  private revalidateInBackground(opts: {
+    paths?: string[];
+    tags?: string[];
+  }) {
     const bypassToken = this.vercelBypassSecret || this.revalidateSecret;
     const url = `${this.frontendUrl}/api/revalidate?x-vercel-set-bypass-cookie=true&x-vercel-protection-bypass=${bypassToken}`;
 
+    const items = opts.paths
+      ? opts.paths.map((path) => ({ path, secret: this.revalidateSecret }))
+      : (opts.tags ?? []).map((tag) => ({ tag, secret: this.revalidateSecret }));
+
     // Fire all revalidation requests in parallel, don't await
     Promise.all(
-      paths.map(async (path) => {
+      items.map(async (body) => {
+        const label = 'path' in body ? `path: ${body.path}` : `tag: ${(body as any).tag}`;
         try {
           const response = await globalThis.fetch(url, {
             method: 'POST',
@@ -53,18 +65,17 @@ export class NotifyAndRevalidateUtil {
               'Content-Type': 'application/json',
               'x-vercel-protection-bypass': bypassToken,
             },
-            body: JSON.stringify({ path, secret: this.revalidateSecret }),
+            body: JSON.stringify(body),
           });
 
           if (!response.ok) {
             console.error(
-              `[NotifyAndRevalidate] Failed to revalidate path: ${path}, status: ${response.status}`,
+              `[NotifyAndRevalidate] Failed to revalidate ${label}, status: ${response.status}`,
             );
           }
         } catch (err) {
           console.error(
-            '[NotifyAndRevalidate] Failed to revalidate path',
-            path,
+            `[NotifyAndRevalidate] Failed to revalidate ${label}`,
             err,
           );
         }


### PR DESCRIPTION
## [1.26.1] - 2026-05-30

### Fixed
- Banner mutations (`create`, `update`, `remove`, `reorder`) now call `revalidateTags: ['banners']` instead of `revalidatePaths: ['/']`, preventing unnecessary invalidation of unrelated caches (schedules, categories, etc.)
- `NotifyAndRevalidateUtil` extended to accept `revalidateTags` option and send `{ tag, secret }` body to the revalidation endpoint

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)