### PR TITLE
Release 1.27.0 - weekStart param for week schedules endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.27.0] - 2026-05-31
+
+### Added
+- `GET /channels/with-schedules/week` now accepts an optional `weekStart=YYYY-MM-DD` query param to return schedules for a specific week instead of the current one
+- Weekly overrides are filtered by the requested week's `weekStartDate`, so cancellations, time changes, and special programs are correctly applied for the target week
+- Backwards compatible: omitting `weekStart` preserves existing behavior (current week)
+
+---
+
 ## [1.26.1] - 2026-05-30
 
 ### Fixed

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -237,6 +237,7 @@ describe('ChannelsController', () => {
         'device123',
         true,
         'false',
+        undefined,
       );
     });
 
@@ -245,6 +246,7 @@ describe('ChannelsController', () => {
 
       expect(result).toEqual([]);
       expect(service.getWeekSchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -259,6 +261,24 @@ describe('ChannelsController', () => {
         'device789',
         false,
         undefined,
+        undefined,
+      );
+    });
+
+    it('should pass weekStart param to service', async () => {
+      const result = await controller.getWeekSchedules(
+        undefined,
+        undefined,
+        undefined,
+        '2026-06-02',
+      );
+
+      expect(result).toEqual([]);
+      expect(service.getWeekSchedules).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        '2026-06-02',
       );
     });
   });

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -123,10 +123,16 @@ export class ChannelsController {
     @Query('deviceId') deviceId?: string,
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
+    @Query('weekStart') weekStart?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
-    return this.channelsService.getWeekSchedules(deviceId, liveStatusBool, raw);
+    return this.channelsService.getWeekSchedules(
+      deviceId,
+      liveStatusBool,
+      raw,
+      weekStart,
+    );
   }
 
   @Get(':id')

--- a/src/channels/channels.integration.spec.ts
+++ b/src/channels/channels.integration.spec.ts
@@ -151,6 +151,7 @@ describe('Channels Endpoints Integration Tests', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
       );
     });
 
@@ -169,6 +170,7 @@ describe('Channels Endpoints Integration Tests', () => {
         'test-device-456',
         true,
         'true',
+        undefined,
       );
     });
 
@@ -182,6 +184,7 @@ describe('Channels Endpoints Integration Tests', () => {
 
       expect(channelsService.getWeekSchedules).toHaveBeenCalledWith(
         'partial-device',
+        undefined,
         undefined,
         undefined,
       );

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -419,6 +419,7 @@ export class ChannelsService {
     deviceId?: string,
     liveStatus?: boolean,
     raw?: string,
+    weekStart?: string,
   ): Promise<ChannelWithSchedules[]> {
     const overallStart = Date.now();
     const requestId = Math.random().toString(36).substr(2, 9);
@@ -470,6 +471,7 @@ export class ChannelsService {
             dayOfWeek: day,
             applyOverrides: raw !== 'true',
             liveStatus: liveStatus || false,
+            weekStart,
           },
         );
 
@@ -619,8 +621,15 @@ export class ChannelsService {
     deviceId?: string,
     liveStatus?: boolean,
     raw?: string,
+    weekStart?: string,
   ): Promise<ChannelWithSchedules[]> {
-    return this.getChannelsWithSchedules(undefined, deviceId, liveStatus, raw);
+    return this.getChannelsWithSchedules(
+      undefined,
+      deviceId,
+      liveStatus,
+      raw,
+      weekStart,
+    );
   }
 
   /**

--- a/src/youtube/optimized-schedules.service.spec.ts
+++ b/src/youtube/optimized-schedules.service.spec.ts
@@ -146,6 +146,55 @@ describe('OptimizedSchedulesService', () => {
     );
   });
 
+  it('should use weekStart option instead of current week when provided', async () => {
+    const mockApplyWeeklyOverrides = jest
+      .fn()
+      .mockImplementation((schedules) => Promise.resolve(schedules));
+    const mockGetWeekStartDate = jest.fn().mockReturnValue('2024-01-01');
+
+    const mockRedisService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+      del: jest.fn(),
+      delByPattern: jest.fn(),
+    };
+    const mockConfigService = { canFetchLive: jest.fn().mockResolvedValue(true) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OptimizedSchedulesService,
+        { provide: SchedulesService, useValue: mockSchedulesService },
+        {
+          provide: WeeklyOverridesService,
+          useValue: {
+            applyWeeklyOverrides: mockApplyWeeklyOverrides,
+            getWeekStartDate: mockGetWeekStartDate,
+          },
+        },
+        {
+          provide: LiveStatusBackgroundService,
+          useValue: mockLiveStatusBackgroundService,
+        },
+        { provide: YoutubeLiveService, useValue: {} },
+        { provide: RedisService, useValue: mockRedisService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    const svc = module.get<OptimizedSchedulesService>(OptimizedSchedulesService);
+
+    await svc.getSchedulesWithOptimizedLiveStatus({
+      liveStatus: false,
+      weekStart: '2026-06-02',
+    });
+
+    expect(mockGetWeekStartDate).not.toHaveBeenCalled();
+    expect(mockApplyWeeklyOverrides).toHaveBeenCalledWith(
+      expect.any(Array),
+      '2026-06-02',
+    );
+  });
+
   it('should set is_live to false when program is escalated to not-found', async () => {
     // Mock Redis to return escalated attempt tracking
     const mockRedisService = {

--- a/src/youtube/optimized-schedules.service.ts
+++ b/src/youtube/optimized-schedules.service.ts
@@ -37,12 +37,13 @@ export class OptimizedSchedulesService {
     // Apply weekly overrides
     let schedulesWithOverrides = schedules;
     if (options.applyOverrides !== false) {
-      const currentWeekStart =
+      const weekStartDate =
+        options.weekStart ||
         this.weeklyOverridesService.getWeekStartDate('current');
       schedulesWithOverrides =
         await this.weeklyOverridesService.applyWeeklyOverrides(
           schedules,
-          currentWeekStart,
+          weekStartDate,
         );
     }
 
@@ -81,12 +82,13 @@ export class OptimizedSchedulesService {
     // Apply weekly overrides
     let schedulesWithOverrides = schedules;
     if (options.applyOverrides !== false) {
-      const currentWeekStart =
+      const weekStartDate =
+        options.weekStart ||
         this.weeklyOverridesService.getWeekStartDate('current');
       schedulesWithOverrides =
         await this.weeklyOverridesService.applyWeeklyOverrides(
           schedules,
-          currentWeekStart,
+          weekStartDate,
         );
     }
     this.logger.debug(


### PR DESCRIPTION
## Summary

- `GET /channels/with-schedules/week` now accepts `weekStart=YYYY-MM-DD` query param to fetch schedules for a specific week
- Weekly overrides (cancellations, time changes, special programs) are applied for the requested week's `weekStartDate`
- Backwards compatible — omitting `weekStart` keeps current behavior unchanged
- Cache is collision-free: overrides are already keyed per `weekly_overrides:{weekStartDate}` in Redis

## Motivation

The frontend grid shows a "overflow zone" (00:00–03:59 of the next day) at the end of each column. On Sundays, that zone must show Monday of the **next** week, so the frontend requests `weekStart=<next-monday>`.

## Test plan

- [ ] `GET /channels/with-schedules/week` without param → same response as before
- [ ] `GET /channels/with-schedules/week?weekStart=2026-06-08` → returns schedules with overrides for that week applied
- [ ] Unit tests: 26/26 passing (`channels.controller.spec`, `optimized-schedules.service.spec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)