### PR TITLE
⚡ Bolt: [performance improvement] Optimize Redis MGET and parallelize config queries in enrichWithCachedLiveStatus

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2024-06-04 - [Optimize Redis MGET for notFoundAttempts in enrichWithCachedLiveStatus]
+**Learning:** Sequential Redis GET operations in a loop within `enrichWithCachedLiveStatus` (`OptimizedSchedulesService`) create an N+1 query pattern, severely impacting performance for retrieving not-found attempts and fetching canFetchLive configurations. While `getSchedulesWithOptimizedLiveStatusV2` addresses this fully for the main path, the older `enrichWithCachedLiveStatus` was still susceptible to this bottleneck.
+**Action:** Replaced sequential `redisService.get` calls with a single batched `redisService.mget` call, and parallelized the `configService.canFetchLive` loop using `Promise.all` + `.map()`, achieving an immediate speedup while preserving the exact fallback logic structure.

--- a/src/youtube/optimized-schedules.service.ts
+++ b/src/youtube/optimized-schedules.service.ts
@@ -403,29 +403,32 @@ export class OptimizedSchedulesService {
 
     // Fetch attempt tracking data for all channels to check for not-found escalation
     const attemptTrackingMap = new Map<string, any>();
-    for (const handle of handles) {
-      const attemptTrackingKey = `notFoundAttempts:${handle}`;
-      const attemptTracking =
-        await this.redisService.get<any>(attemptTrackingKey);
-      if (attemptTracking) {
-        attemptTrackingMap.set(handle, attemptTracking);
+    if (handles.length > 0) {
+      const attemptKeys = handles.map((h) => `notFoundAttempts:${h}`);
+      const attemptResults = await this.redisService.mget<any>(attemptKeys);
+      for (let i = 0; i < handles.length; i++) {
+        if (attemptResults[i]) {
+          attemptTrackingMap.set(handles[i], attemptResults[i]);
+        }
       }
     }
 
     // Check canFetchLive for all handles (respects holiday overrides)
     const canFetchLiveMap = new Map<string, boolean>();
-    for (const handle of handles) {
-      try {
-        const canFetch = await this.configService.canFetchLive(handle);
-        canFetchLiveMap.set(handle, canFetch);
-      } catch (error) {
-        // If we can't check the config, assume fetching is enabled
-        this.logger.debug(
-          `[OPTIMIZED-SCHEDULES] Error checking canFetchLive for ${handle}, assuming enabled`,
-        );
-        canFetchLiveMap.set(handle, true);
-      }
-    }
+    await Promise.all(
+      handles.map(async (handle) => {
+        try {
+          const canFetch = await this.configService.canFetchLive(handle);
+          canFetchLiveMap.set(handle, canFetch);
+        } catch (error) {
+          // If we can't check the config, assume fetching is enabled
+          this.logger.debug(
+            `[OPTIMIZED-SCHEDULES] Error checking canFetchLive for ${handle}, assuming enabled`,
+          );
+          canFetchLiveMap.set(handle, true);
+        }
+      }),
+    );
 
     // Enrich schedules with cached live status
     const enriched: any[] = [];


### PR DESCRIPTION
💡 **What:** Replaced sequential `redisService.get` calls with a single batched `redisService.mget` call in `OptimizedSchedulesService.enrichWithCachedLiveStatus`. Wrapped the `configService.canFetchLive` sequential loop in `Promise.all` with `.map()` for concurrency.

🎯 **Why:** To eliminate the N+1 database/Redis query pattern that occurs during schedule enrichment, which severely impacts performance when processing multiple handles simultaneously.

📊 **Impact:** Significantly reduces I/O wait times and network latency by executing multiple Redis operations in a single round-trip and running async config lookups in parallel.

🔬 **Measurement:** Verify performance by observing reduced response times in API endpoints that trigger schedule enrichment with live status updates. No functionality regressions should occur as test suites validate type-safety and syntax, maintaining identical logical structure with fallback defaults preserved.

---
*PR created automatically by Jules for task [9770400367682018288](https://jules.google.com/task/9770400367682018288) started by @matiasrozenblum*