### PR TITLE
fix: detect web frontend via Origin header to skip midnight split (v1.28.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.28.1] - 2026-06-06
+
+### Fixed
+- Web frontend no longer receives split cross-midnight blocks: the backend now identifies frontend requests via the `Origin` header (matched against `FRONTEND_URL` env var) and returns unified blocks directly, without requiring any header change on the frontend side. Old mobile clients (no `X-App-Version` header or version < 1.0.9) continue to receive the split format for backward compatibility.
+
+---
+
 ## [1.28.0] - 2026-06-04
 
 ### Fixed

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -13,7 +13,7 @@ import {
   BadRequestException,
   Headers,
 } from '@nestjs/common';
-import { isAtLeastVersion } from '../utils/app-version.util';
+import { needsMidnightSplit } from '../utils/app-version.util';
 import { splitCrossMidnightSchedules } from '../utils/midnight-split.util';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ChannelsService } from './channels.service';
@@ -60,6 +60,7 @@ export class ChannelsController {
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -69,7 +70,7 @@ export class ChannelsController {
       liveStatusBool,
       raw,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;
@@ -88,6 +89,7 @@ export class ChannelsController {
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -96,7 +98,7 @@ export class ChannelsController {
       liveStatusBool,
       raw,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;
@@ -115,6 +117,7 @@ export class ChannelsController {
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -123,7 +126,7 @@ export class ChannelsController {
       liveStatusBool,
       raw,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;
@@ -143,6 +146,7 @@ export class ChannelsController {
     @Query('raw') raw?: string,
     @Query('weekStart') weekStart?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -152,7 +156,7 @@ export class ChannelsController {
       raw,
       weekStart,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;

--- a/src/utils/app-version.util.spec.ts
+++ b/src/utils/app-version.util.spec.ts
@@ -1,4 +1,4 @@
-import { isAtLeastVersion } from './app-version.util';
+import { isAtLeastVersion, needsMidnightSplit } from './app-version.util';
 
 describe('isAtLeastVersion', () => {
   describe('returns false for missing/invalid version', () => {
@@ -43,5 +43,39 @@ describe('isAtLeastVersion', () => {
     it('returns false when patch is below min (1.0.8)', () => {
       expect(isAtLeastVersion('1.0.8', '1.0.9')).toBe(false);
     });
+  });
+});
+
+describe('needsMidnightSplit', () => {
+  const FRONTEND = 'https://staging.laguiadelstreaming.com';
+
+  beforeEach(() => {
+    process.env.FRONTEND_URL = FRONTEND;
+  });
+
+  it('returns false (no split) when Origin matches the frontend URL', () => {
+    expect(needsMidnightSplit(undefined, FRONTEND)).toBe(false);
+  });
+
+  it('returns false when Origin matches frontend URL with trailing slash', () => {
+    expect(needsMidnightSplit(undefined, `${FRONTEND}/`)).toBe(false);
+  });
+
+  it('returns false when mobile sends version >= 1.0.9', () => {
+    expect(needsMidnightSplit('1.0.9', undefined)).toBe(false);
+    expect(needsMidnightSplit('1.1.0', undefined)).toBe(false);
+    expect(needsMidnightSplit('2.0.0', undefined)).toBe(false);
+  });
+
+  it('returns true (split) when no header is present and Origin is absent', () => {
+    expect(needsMidnightSplit(undefined, undefined)).toBe(true);
+  });
+
+  it('returns true when version is below 1.0.9 and Origin is absent', () => {
+    expect(needsMidnightSplit('1.0.8', undefined)).toBe(true);
+  });
+
+  it('returns true when Origin does not match frontend URL', () => {
+    expect(needsMidnightSplit(undefined, 'https://some-other-origin.com')).toBe(true);
   });
 });

--- a/src/utils/app-version.util.ts
+++ b/src/utils/app-version.util.ts
@@ -25,3 +25,25 @@ export function isAtLeastVersion(
   if (min !== minMin) return min > minMin;
   return pat >= patMin;
 }
+
+/**
+ * Returns true when the response should split cross-midnight schedules into two blocks.
+ *
+ * Unified format is returned when:
+ *  - The request Origin matches the web frontend (identified via FRONTEND_URL env var), OR
+ *  - The mobile client sends X-App-Version >= 1.0.9.
+ *
+ * Everything else (old mobile, no header) receives the split format for backward compat.
+ */
+export function needsMidnightSplit(
+  appVersion: string | undefined,
+  origin: string | undefined,
+): boolean {
+  const frontendUrl = (
+    process.env.FRONTEND_URL || 'https://staging.laguiadelstreaming.com'
+  ).replace(/\/$/, '');
+
+  if (origin && origin.replace(/\/$/, '') === frontendUrl) return false;
+  if (isAtLeastVersion(appVersion, '1.0.9')) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

- The web frontend was receiving cross-midnight schedules split into two blocks because it doesn't send `X-App-Version`. This fix identifies frontend requests by their `Origin` header (matched against the `FRONTEND_URL` env var) and returns unified blocks directly — no frontend changes required.
- Old mobile clients (no header or version < 1.0.9) continue to receive the split format for backward compatibility.

## Changes

- `app-version.util.ts`: added `needsMidnightSplit(appVersion, origin)` — returns `false` for requests from the known frontend origin or from mobile >= 1.0.9
- `channels.controller.ts`: all 4 `/channels/with-schedules*` endpoints now also read the `Origin` header and pass it to `needsMidnightSplit`
- Tests updated accordingly

## Test plan

- [x] `npm test` — all suites pass
- [x] `npm run build` — clean compile
- [x] Deployed and validated on staging
- [ ] Verify frontend shows unified cross-midnight block (single block 23:00–01:00)
- [ ] Verify old mobile (no header) still receives split blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)