### PR TITLE
Release 1.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ---
 
+## [1.28.1] - 2026-06-06
+
+### Fixed
+- Web frontend no longer receives split cross-midnight blocks: the backend now identifies frontend requests via the `Origin` header (matched against `FRONTEND_URL` env var) and returns unified blocks directly, without requiring any header change on the frontend side. Old mobile clients (no `X-App-Version` header or version < 1.0.9) continue to receive the split format for backward compatibility.
+
+---
+
 ## [1.28.0] - 2026-06-04
 
 ### Fixed

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -13,7 +13,7 @@ import {
   BadRequestException,
   Headers,
 } from '@nestjs/common';
-import { isAtLeastVersion } from '../utils/app-version.util';
+import { needsMidnightSplit } from '../utils/app-version.util';
 import { splitCrossMidnightSchedules } from '../utils/midnight-split.util';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ChannelsService } from './channels.service';
@@ -60,6 +60,7 @@ export class ChannelsController {
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -69,7 +70,7 @@ export class ChannelsController {
       liveStatusBool,
       raw,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;
@@ -88,6 +89,7 @@ export class ChannelsController {
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -96,7 +98,7 @@ export class ChannelsController {
       liveStatusBool,
       raw,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;
@@ -115,6 +117,7 @@ export class ChannelsController {
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -123,7 +126,7 @@ export class ChannelsController {
       liveStatusBool,
       raw,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;
@@ -143,6 +146,7 @@ export class ChannelsController {
     @Query('raw') raw?: string,
     @Query('weekStart') weekStart?: string,
     @Headers('x-app-version') appVersion?: string,
+    @Headers('origin') origin?: string,
   ) {
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
@@ -152,7 +156,7 @@ export class ChannelsController {
       raw,
       weekStart,
     );
-    if (!isAtLeastVersion(appVersion, '1.0.9')) {
+    if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
     }
     return result;

--- a/src/utils/app-version.util.spec.ts
+++ b/src/utils/app-version.util.spec.ts
@@ -1,4 +1,4 @@
-import { isAtLeastVersion } from './app-version.util';
+import { isAtLeastVersion, needsMidnightSplit } from './app-version.util';
 
 describe('isAtLeastVersion', () => {
   describe('returns false for missing/invalid version', () => {
@@ -43,5 +43,39 @@ describe('isAtLeastVersion', () => {
     it('returns false when patch is below min (1.0.8)', () => {
       expect(isAtLeastVersion('1.0.8', '1.0.9')).toBe(false);
     });
+  });
+});
+
+describe('needsMidnightSplit', () => {
+  const FRONTEND = 'https://staging.laguiadelstreaming.com';
+
+  beforeEach(() => {
+    process.env.FRONTEND_URL = FRONTEND;
+  });
+
+  it('returns false (no split) when Origin matches the frontend URL', () => {
+    expect(needsMidnightSplit(undefined, FRONTEND)).toBe(false);
+  });
+
+  it('returns false when Origin matches frontend URL with trailing slash', () => {
+    expect(needsMidnightSplit(undefined, `${FRONTEND}/`)).toBe(false);
+  });
+
+  it('returns false when mobile sends version >= 1.0.9', () => {
+    expect(needsMidnightSplit('1.0.9', undefined)).toBe(false);
+    expect(needsMidnightSplit('1.1.0', undefined)).toBe(false);
+    expect(needsMidnightSplit('2.0.0', undefined)).toBe(false);
+  });
+
+  it('returns true (split) when no header is present and Origin is absent', () => {
+    expect(needsMidnightSplit(undefined, undefined)).toBe(true);
+  });
+
+  it('returns true when version is below 1.0.9 and Origin is absent', () => {
+    expect(needsMidnightSplit('1.0.8', undefined)).toBe(true);
+  });
+
+  it('returns true when Origin does not match frontend URL', () => {
+    expect(needsMidnightSplit(undefined, 'https://some-other-origin.com')).toBe(true);
   });
 });

--- a/src/utils/app-version.util.ts
+++ b/src/utils/app-version.util.ts
@@ -25,3 +25,25 @@ export function isAtLeastVersion(
   if (min !== minMin) return min > minMin;
   return pat >= patMin;
 }
+
+/**
+ * Returns true when the response should split cross-midnight schedules into two blocks.
+ *
+ * Unified format is returned when:
+ *  - The request Origin matches the web frontend (identified via FRONTEND_URL env var), OR
+ *  - The mobile client sends X-App-Version >= 1.0.9.
+ *
+ * Everything else (old mobile, no header) receives the split format for backward compat.
+ */
+export function needsMidnightSplit(
+  appVersion: string | undefined,
+  origin: string | undefined,
+): boolean {
+  const frontendUrl = (
+    process.env.FRONTEND_URL || 'https://staging.laguiadelstreaming.com'
+  ).replace(/\/$/, '');
+
+  if (origin && origin.replace(/\/$/, '') === frontendUrl) return false;
+  if (isAtLeastVersion(appVersion, '1.0.9')) return false;
+  return true;
+}


### PR DESCRIPTION
## [1.28.1] - 2026-06-06

### Added
- `GET /channels/with-schedules/week` accepts optional `weekStart=YYYY-MM-DD` to return schedules for a specific week
- `TimezoneUtil.isTimeInRange()` and `TimezoneUtil.previousDayOfWeek()` helpers for cross-midnight-aware time logic
- API versioning on `/channels/with-schedules*`: mobile >= 1.0.9 receives unified cross-midnight blocks; older clients receive split blocks for backward compat

### Fixed
- `is_live` detection for cross-midnight programs (e.g. 23:00–00:30): time range check now correctly handles `end_time < start_time` with OR logic and also checks previous-day schedules in early-morning hours
- Web frontend now correctly receives unified cross-midnight blocks, detected via `Origin` header matched against `FRONTEND_URL` (no frontend changes required)
- `getBlockTTL` utility fixed for cross-midnight schedules
- Banner mutations now use `revalidateTags` instead of `revalidatePaths`, preventing unnecessary cache invalidation

---
Merging this PR to `main` will trigger the **production deploy on Railway**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)