### PR TITLE
⚡ Bolt: Optimize Redis operations for bulk overrides deletion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2025-02-12 - N+1 Query Anti-Pattern in Redis Iterations
+**Learning:** Sequential `RedisService.get` and `RedisService.del` loops operating on keys returned by `scanStream` can quickly exhaust network connections and dramatically slow down execution, acting as a severe N+1 bottleneck. While the pipeline abstraction was previously noted, using explicit `RedisService.mget` combined with chunked batching (`batch_size=500`) and array-based `RedisService.del([keys])` provides identical correctness with $O(1)$ database trips per chunk.
+**Action:** When working with collections of Redis keys derived from scans or lookups, always prefer array-based mapping and chunked `mget`/bulk `del` operations over raw `for...of` loops calling single-key operations.

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -33,6 +33,7 @@ describe('WeeklyOverridesService', () => {
 
   const mockRedisService = {
     get: jest.fn(),
+    mget: jest.fn(),
     set: jest.fn(),
     del: jest.fn(),
     delByPattern: jest.fn(),

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1212,16 +1212,29 @@ export class WeeklyOverridesService {
       keys.push(...keyChunk);
     }
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+    const keysToDelete: string[] = [];
+
+    // Process keys in chunks to avoid overwhelming Redis or maximum call stack sizes
+    const BATCH_SIZE = 500;
+    for (let i = 0; i < keys.length; i += BATCH_SIZE) {
+      const batchKeys = keys.slice(i, i + BATCH_SIZE);
+      const overrides = await this.redisService.mget<WeeklyOverride>(batchKeys);
+
+      for (let j = 0; j < overrides.length; j++) {
+        const override = overrides[j];
+        if (!override) continue;
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          keysToDelete.push(batchKeys[j]);
+        }
       }
+    }
+
+    if (keysToDelete.length > 0) {
+      await this.redisService.del(keysToDelete);
+      deleted = keysToDelete.length;
     }
     if (deleted > 0) {
       await this.redisService.del('schedules:week:complete');


### PR DESCRIPTION
💡 What: Replaced sequential `RedisService.get()` and `RedisService.del()` operations within a loop in `deleteOverridesForProgram` with batched chunking using `RedisService.mget()` and an array-based bulk `RedisService.del()`.
🎯 Why: Iterating over hundreds of Redis keys obtained via `scanStream` and sequentially fetching/deleting them caused severe N+1 network roundtrips. Batching drastically reduces the number of roundtrips from O(N) to O(N/500).
📊 Impact: Reduces network I/O overhead significantly when deleting program schedules; instead of hundreds of sequential queries, it completes in a minimum of 2 roundtrips (1 mget, 1 del) per 500 records.
🔬 Measurement: Verify by executing tests and measuring time taken to delete a program with dozens of weekly overrides; network profiler will show batched MGET and DEL commands instead of repetitive singular commands.

---
*PR created automatically by Jules for task [17868599210072474989](https://jules.google.com/task/17868599210072474989) started by @matiasrozenblum*