### PR TITLE
⚡ Bolt: [performance improvement] Batched Redis deletes and gets in WeeklyOverridesService

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-03-24 - [N+1 Redis Query Avoidance in Weekly Overrides Cleanup]
+**Learning:** Found N+1 Redis query patterns inside `WeeklyOverridesService` cleanup routines. Sequential `await this.redisService.get(key)` inside loops max out connection overhead, and `await this.redisService.del(key)` in a loop incurs heavy penalties. Also learned that when swapping `get` for `mget` in services, the corresponding test mock `mget: jest.fn().mockResolvedValue([])` is strictly required to prevent test crashes when tests iterate over the result.
+**Action:** Replace `for` loops of `.get()` with chunked `this.redisService.mget(keys)` to prevent call stack limits, and batch delete keys using `this.redisService.del(keysArray)` instead of single-key loops. Ensure test mocks reflect array return types.

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -33,6 +33,7 @@ describe('WeeklyOverridesService', () => {
 
   const mockRedisService = {
     get: jest.fn(),
+    mget: jest.fn().mockResolvedValue([]),
     set: jest.fn(),
     del: jest.fn(),
     delByPattern: jest.fn(),
@@ -892,9 +893,9 @@ describe('WeeklyOverridesService', () => {
       const result = await service.cleanupExpiredOverrides();
 
       expect(result).toBe(1);
-      expect(redisService.del).toHaveBeenCalledWith(
+      expect(redisService.del).toHaveBeenCalledWith([
         'weekly_override:1_2024-01-01',
-      );
+      ]);
       expect(redisService.del).toHaveBeenCalledWith('schedules:week:complete');
     });
 

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1180,9 +1180,10 @@ export class WeeklyOverridesService {
       });
 
       // Delete expired overrides
-      for (const key of expiredKeys) {
-        await this.redisService.del(key);
-        cleaned++;
+      // OPTIMIZATION: Delete all expired overrides in a single batched round-trip to prevent N+1 Redis network overhead
+      if (expiredKeys.length > 0) {
+        await this.redisService.del(expiredKeys);
+        cleaned += expiredKeys.length;
       }
     }
 
@@ -1212,16 +1213,30 @@ export class WeeklyOverridesService {
       keys.push(...keyChunk);
     }
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+    const keysToDelete: string[] = [];
+
+    // OPTIMIZATION: Use mget in chunks to prevent N+1 Redis gets, avoiding maximum call stack limits
+    const chunkSize = 500;
+    for (let i = 0; i < keys.length; i += chunkSize) {
+      const chunk = keys.slice(i, i + chunkSize);
+      const overrides = await this.redisService.mget<WeeklyOverride>(chunk);
+
+      for (let j = 0; j < overrides.length; j++) {
+        const override = overrides[j];
+        if (!override) continue;
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          keysToDelete.push(chunk[j]);
+        }
       }
+    }
+
+    // OPTIMIZATION: Delete all matched overrides in a single batched round-trip
+    if (keysToDelete.length > 0) {
+      await this.redisService.del(keysToDelete);
+      deleted = keysToDelete.length;
     }
     if (deleted > 0) {
       await this.redisService.del('schedules:week:complete');


### PR DESCRIPTION
💡 What: Optimized `WeeklyOverridesService` cleanup operations by replacing sequential Redis `get` and `del` operations with batched `mget` array queries (processed in chunks of 500 to avoid maximum call stack limits) and array-based `del` commands. Also added the correct `mget` mock to `weekly-overrides.service.spec.ts` resolving to an array to prevent iteration-based test failures.

🎯 Why: The original implementation caused a severe N+1 Redis network bottleneck when managing and cleaning up weekly schedule overrides, unnecessarily tying up the event loop and consuming Redis connections.

📊 Impact: Significantly reduces network overhead and speeds up the cleanup job and specific program override deletion paths, moving from O(N) sequential Redis network operations to O(N/500) chunked operations, greatly lowering latency and event loop blocking.

🔬 Measurement: Verify by executing the `cleanupExpiredOverrides` or `deleteOverridesForProgram` procedures and observing the reduced number of Redis network commands via APM metrics. All test suites pass correctly with the updated dummy mock structure.

---
*PR created automatically by Jules for task [11436349523909377229](https://jules.google.com/task/11436349523909377229) started by @matiasrozenblum*