### PR TITLE
⚡ Bolt: [fix N+1 Redis query bottleneck during weekly overrides deletion]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-03-24 - [N+1 Redis Query Avoidance when Deleting Weekly Overrides]
+**Learning:** In `WeeklyOverridesService`, an N+1 query pattern was identified when fetching overrides inside the `deleteOverridesForProgram` loop using individual `await this.redisService.get(key)` calls. This forced Redis to handle multiple sequential network round-trips.
+**Action:** Replaced sequential `get` calls with a single batched `mget` round-trip. Similarly, batched the cleanup logic to use a single array-based `this.redisService.del(keysToDelete)` call, dropping network latency from $O(N)$ to $O(1)$. Always check if arrays are empty (`keys.length > 0`) before issuing batched Redis commands.

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1212,15 +1212,26 @@ export class WeeklyOverridesService {
       keys.push(...keyChunk);
     }
     let deleted = 0;
-    for (const key of keys) {
-      const override = await this.redisService.get<WeeklyOverride>(key);
-      if (!override) continue;
-      if (
-        (override.programId && override.programId === programId) ||
-        (override.scheduleId && scheduleIds.includes(override.scheduleId))
-      ) {
-        await this.redisService.del(key);
-        deleted++;
+    // Avoid N+1 redis sequential queries by fetching all overrides via mget
+    if (keys.length > 0) {
+      const overrides = await this.redisService.mget<WeeklyOverride>(keys);
+      const keysToDelete: string[] = [];
+
+      for (let i = 0; i < overrides.length; i++) {
+        const override = overrides[i];
+        if (!override) continue;
+
+        if (
+          (override.programId && override.programId === programId) ||
+          (override.scheduleId && scheduleIds.includes(override.scheduleId))
+        ) {
+          keysToDelete.push(keys[i]);
+        }
+      }
+
+      if (keysToDelete.length > 0) {
+        await this.redisService.del(keysToDelete);
+        deleted = keysToDelete.length;
       }
     }
     if (deleted > 0) {


### PR DESCRIPTION
💡 **What:**
Replaced the sequential `await this.redisService.get(key)` inside the `for` loop of `WeeklyOverridesService.deleteOverridesForProgram` with a single `mget` batched call, and refactored the multiple `await this.redisService.del(key)` calls into a single batched array deletion.

🎯 **Why:**
Using sequential asynchronous Redis `get` and `del` commands inside a loop creates an N+1 query pattern, which creates significant unneeded network round-trip overhead.

📊 **Impact:**
Reduces network round-trips to Redis during program override deletions from $O(N)$ to $O(1)$ operations, substantially improving deletion execution times. 

🔬 **Measurement:**
This logic can be verified directly via the performance reduction in Redis connection calls when clearing weekly overrides.

---
*PR created automatically by Jules for task [4128606752741327832](https://jules.google.com/task/4128606752741327832) started by @matiasrozenblum*