### PR TITLE
Release 1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+---
+
+## [1.29.0] - 2026-06-10
+
 ### Added
 - `is_premiere` boolean field on `Program` entity (default `false`). When enabled, the cron will use a `playlistItems` fallback to detect YouTube premieres (estrenos) that are not returned by `search?eventType=live`.
-- `POST /channels/:id/fetch-premiere` endpoint: manually triggers the premiere fallback for all programs currently on-air on the given channel. Bypasses the `is_premiere` flag — intended for backoffice use when a channel is detected broadcasting an estreno. Clears not-found Redis flags before fetching and caches any found video ID.
+- `POST /channels/:id/fetch-premiere` endpoint: manually triggers the premiere fallback for all programs currently on-air on the given channel. Bypasses the `is_premiere` flag — intended for backoffice use. Clears not-found Redis flags before fetching and caches any found video ID.
+- `is_premiere` support for special programs (weekly overrides of type `create`): the flag is stored in the override's `specialProgram` object and propagated to the virtual program used by the live-fetch flow.
 
 ### Fixed
-- YouTube premieres (estrenos) are now detected as live streams when `is_premiere` is set on the program. The `search?eventType=live` API does not return premieres, but `videos?part=snippet` correctly reports them as `liveBroadcastContent=live`. The fallback checks the channel's 3 most recent uploads via `playlistItems` (1 quota unit vs 100 for a second search) and uses title-similarity matching (`SimilarityUtil`) to pick the best match when multiple premieres are live simultaneously.
+- YouTube premieres (estrenos) are now detected as live streams when `is_premiere` is set on the program. The `search?eventType=live` API does not return premieres, but `videos?part=snippet` correctly reports them as `liveBroadcastContent=live`. The fallback checks the channel's 3 most recent uploads via `playlistItems` (1 quota unit vs 100 for a second search) and uses title-similarity matching to pick the best match when multiple premieres are live simultaneously.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+### Added
+- `is_premiere` boolean field on `Program` entity (default `false`). When enabled, the cron will use a `playlistItems` fallback to detect YouTube premieres (estrenos) that are not returned by `search?eventType=live`.
+- `POST /channels/:id/fetch-premiere` endpoint: manually triggers the premiere fallback for all programs currently on-air on the given channel. Bypasses the `is_premiere` flag — intended for backoffice use when a channel is detected broadcasting an estreno. Clears not-found Redis flags before fetching and caches any found video ID.
+
+### Fixed
+- YouTube premieres (estrenos) are now detected as live streams when `is_premiere` is set on the program. The `search?eventType=live` API does not return premieres, but `videos?part=snippet` correctly reports them as `liveBroadcastContent=live`. The fallback checks the channel's 3 most recent uploads via `playlistItems` (1 quota unit vs 100 for a second search) and uses title-similarity matching (`SimilarityUtil`) to pick the best match when multiple premieres are live simultaneously.
+
 ---
 
 ## [1.28.1] - 2026-06-06

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -6,6 +6,7 @@ import { UpdateChannelDto } from './dto/update-channel.dto';
 import { Channel } from './channels.entity';
 import { NotFoundException } from '@nestjs/common';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
+import { YoutubeLiveService } from '../youtube/youtube-live.service';
 
 describe('ChannelsController', () => {
   let controller: ChannelsController;
@@ -57,6 +58,10 @@ describe('ChannelsController', () => {
         {
           provide: SupabaseStorageService,
           useValue: mockSupabaseStorageService,
+        },
+        {
+          provide: YoutubeLiveService,
+          useValue: { fetchPremiereForChannel: jest.fn().mockResolvedValue([]) },
         },
       ],
     }).compile();

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -31,6 +31,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
+import { YoutubeLiveService } from '../youtube/youtube-live.service';
 
 @ApiTags('channels') // Etiqueta para los canales
 @Controller('channels')
@@ -38,6 +39,7 @@ export class ChannelsController {
   constructor(
     private readonly channelsService: ChannelsService,
     private readonly supabaseStorageService: SupabaseStorageService,
+    private readonly youtubeLiveService: YoutubeLiveService,
   ) {}
 
   @Get()
@@ -273,5 +275,48 @@ export class ChannelsController {
     }
     const result = await this.channelsService.clearChannelCache(channel.handle);
     return { message: 'Cache cleared successfully', ...result };
+  }
+
+  @Post(':id/fetch-premiere')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary:
+      'Trigger premiere fallback fetch for all currently on-air programs of this channel',
+    description:
+      'Bypasses is_premiere flag — intended for manual use from the backoffice when a channel is broadcasting a premiere (estreno). Clears not-found flags and checks recent uploads via playlistItems.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Results per on-air program',
+    schema: {
+      type: 'object',
+      properties: {
+        results: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              programName: { type: 'string' },
+              videoId: { type: 'string', nullable: true },
+              found: { type: 'boolean' },
+            },
+          },
+        },
+      },
+    },
+  })
+  async fetchPremiere(@Param('id') id: number) {
+    const channel = await this.channelsService.findOne(id);
+    if (!channel.youtube_channel_id || !channel.handle) {
+      throw new BadRequestException(
+        'Channel does not have a YouTube channel ID or handle',
+      );
+    }
+    const results = await this.youtubeLiveService.fetchPremiereForChannel(
+      channel.youtube_channel_id,
+      channel.handle,
+    );
+    return { results };
   }
 }

--- a/src/channels/channels.integration.spec.ts
+++ b/src/channels/channels.integration.spec.ts
@@ -5,6 +5,7 @@ import { ChannelsController } from '../channels/channels.controller';
 import { ChannelsService } from '../channels/channels.service';
 import { TimezoneUtil } from '../utils/timezone.util';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
+import { YoutubeLiveService } from '../channels/../youtube/youtube-live.service';
 
 describe('Channels Endpoints Integration Tests', () => {
   let app: INestApplication;
@@ -66,6 +67,10 @@ describe('Channels Endpoints Integration Tests', () => {
         {
           provide: SupabaseStorageService,
           useValue: { uploadImage: jest.fn() },
+        },
+        {
+          provide: YoutubeLiveService,
+          useValue: { fetchPremiereForChannel: jest.fn().mockResolvedValue([]) },
         },
       ],
     }).compile();

--- a/src/migrations/1780960227836-AddIsPremiereToProgramTable.ts
+++ b/src/migrations/1780960227836-AddIsPremiereToProgramTable.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddIsPremiereToProgramTable1780960227836 implements MigrationInterface {
+    name = 'AddIsPremiereToProgramTable1780960227836'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "program" ADD "is_premiere" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "program" DROP COLUMN "is_premiere"`);
+    }
+}

--- a/src/programs/programs.entity.ts
+++ b/src/programs/programs.entity.ts
@@ -58,4 +58,7 @@ export class Program {
 
   @Column({ type: 'boolean', default: true })
   is_visible: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  is_premiere: boolean;
 }

--- a/src/schedules/schedules-logging.spec.ts
+++ b/src/schedules/schedules-logging.spec.ts
@@ -51,6 +51,7 @@ describe('SchedulesService Logging Improvements', () => {
       stream_url: null,
       style_override: null,
       is_visible: true,
+      is_premiere: false,
     },
   };
 

--- a/src/schedules/schedules.service.spec.ts
+++ b/src/schedules/schedules.service.spec.ts
@@ -897,6 +897,7 @@ describe('SchedulesService', () => {
             stream_url: '',
             style_override: null,
             is_visible: true,
+            is_premiere: false,
             channel: {
               id: 1,
               name: 'Vorterix',

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -39,6 +39,7 @@ export interface WeeklyOverrideDto {
     channelId: number;
     imageUrl?: string;
     stream_url?: string;
+    is_premiere?: boolean;
   };
 }
 
@@ -81,6 +82,7 @@ export interface WeeklyOverride {
     };
     imageUrl?: string;
     stream_url?: string;
+    is_premiere?: boolean;
   };
 }
 
@@ -1089,6 +1091,7 @@ export class WeeklyOverridesService {
             description: override.specialProgram.description || '',
             logo_url: override.specialProgram.imageUrl || '',
             stream_url: override.specialProgram.stream_url || null,
+            is_premiere: override.specialProgram.is_premiere ?? false,
             channel: channel
               ? {
                   id: channel.id,

--- a/src/users/subscription.service.spec.ts
+++ b/src/users/subscription.service.spec.ts
@@ -60,6 +60,7 @@ describe('SubscriptionService', () => {
     panelists: [],
     schedules: [],
     style_override: null,
+    is_premiere: false,
   };
 
   const mockSubscription: UserSubscription = {

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -760,6 +760,7 @@ export class YoutubeLiveService {
     cronType: 'main' | 'back-to-back-fix' | 'manual',
   ): Promise<LiveStreamsResult | null | '__SKIPPED__'> {
     let currentProgramName: string | null = null;
+    let currentProgramIsPremiere = false;
 
     // gating centralizado
     try {
@@ -818,6 +819,8 @@ export class YoutubeLiveService {
 
       if (visibleCurrentSchedule?.program) {
         currentProgramName = visibleCurrentSchedule.program.name; // Capture name for sorting logic
+        currentProgramIsPremiere =
+          visibleCurrentSchedule.program.is_premiere ?? false;
       }
     } catch (visErr) {
       // Non-fatal: if visibility check fails, proceed as before
@@ -1000,6 +1003,24 @@ export class YoutubeLiveService {
         );
       }
 
+      if (liveStreams.length === 0 && currentProgramIsPremiere) {
+        // Fallback: YouTube premieres (estrenos) don't appear in search?eventType=live
+        // but ARE reported as liveBroadcastContent=live by the videos API.
+        // Only runs when the current program is flagged as is_premiere to avoid
+        // wasting quota on channels that are genuinely offline.
+        const premiereStream = await this.findActivePremiereFromUploads(
+          channelId,
+          handle,
+          currentProgramName,
+        );
+        if (premiereStream) {
+          liveStreams.push(premiereStream);
+          this.logger.debug(
+            `🎬 [Premiere] Found active premiere for ${handle}: ${premiereStream.videoId} - ${premiereStream.title}`,
+          );
+        }
+      }
+
       if (liveStreams.length === 0) {
         this.logger.debug(
           `🚫 No actually live streams for ${handle} (${context}) - all were scheduled`,
@@ -1171,6 +1192,82 @@ export class YoutubeLiveService {
     );
   }
 
+  /**
+   * Fallback for YouTube premieres (estrenos): the search?eventType=live endpoint does not
+   * return premieres, but videos?part=snippet correctly reports them as liveBroadcastContent=live.
+   * Fetches the channel's 3 most recent uploads via playlistItems (1 quota unit) and checks
+   * each one with isVideoLive().
+   */
+  private async findActivePremiereFromUploads(
+    channelId: string,
+    handle: string,
+    currentProgramName: string | null = null,
+  ): Promise<LiveStream | null> {
+    try {
+      // Uploads playlist ID = channel ID with 'UC' prefix replaced by 'UU'
+      const uploadsPlaylistId = channelId.replace(/^UC/, 'UU');
+
+      const { data } = await axios.get(`${this.apiUrl}/playlistItems`, {
+        params: {
+          part: 'snippet',
+          playlistId: uploadsPlaylistId,
+          maxResults: 3,
+          key: this.apiKey,
+        },
+      });
+
+      const items: any[] = data.items || [];
+      this.logger.debug(
+        `🎬 [Premiere] Checking ${items.length} recent uploads for ${handle}`,
+      );
+
+      const liveStreams: LiveStream[] = [];
+      for (const item of items) {
+        const videoId = item.snippet?.resourceId?.videoId;
+        if (!videoId) continue;
+
+        const isLive = await this.isVideoLive(videoId);
+        if (isLive) {
+          liveStreams.push({
+            videoId,
+            title: item.snippet.title,
+            publishedAt: item.snippet.publishedAt,
+            description: item.snippet.description,
+            thumbnailUrl: item.snippet.thumbnails?.medium?.url,
+            channelTitle: item.snippet.channelTitle,
+          });
+        }
+      }
+
+      if (liveStreams.length === 0) return null;
+
+      // When multiple premieres are live simultaneously, pick the best title match
+      if (liveStreams.length > 1 && currentProgramName) {
+        liveStreams.sort(
+          (a, b) =>
+            SimilarityUtil.calculateTitleSimilarity(
+              currentProgramName,
+              b.title,
+            ) -
+            SimilarityUtil.calculateTitleSimilarity(
+              currentProgramName,
+              a.title,
+            ),
+        );
+        this.logger.debug(
+          `🎬 [Premiere] Multiple live premieres for ${handle}, selected best match: ${liveStreams[0].videoId} - ${liveStreams[0].title}`,
+        );
+      }
+
+      return liveStreams[0];
+    } catch (err) {
+      this.logger.warn(
+        `⚠️ [Premiere] Fallback check failed for ${handle}: ${err.message}`,
+      );
+      return null;
+    }
+  }
+
   public async isVideoLive(videoId: string): Promise<boolean> {
     try {
       // Track API usage
@@ -1183,6 +1280,97 @@ export class YoutubeLiveService {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Manual premiere fetch triggered by the backoffice.
+   * Clears not-found flags then runs the premiere fallback for all programs
+   * currently on-air on the given channel, regardless of the is_premiere flag.
+   */
+  async fetchPremiereForChannel(
+    channelId: string,
+    handle: string,
+  ): Promise<
+    Array<{ programName: string; videoId: string | null; found: boolean }>
+  > {
+    // Clear any not-found / in-flight flags so the fetch isn't blocked
+    await this.redisService.del([
+      `videoIdNotFound:${handle}`,
+      `notFoundAttempts:${handle}`,
+      `fetching:${channelId}`,
+      `liveStatusByHandle:${handle}`,
+    ]);
+
+    const currentDay = TimezoneUtil.currentDayOfWeek();
+    const currentTimeInMinutes = TimezoneUtil.currentTimeInMinutes();
+
+    const schedules = await this.schedulesService.findAll({
+      dayOfWeek: currentDay,
+      liveStatus: false,
+      applyOverrides: true,
+    });
+
+    const onAirPrograms = schedules.filter((s) => {
+      if (s.program?.channel?.youtube_channel_id !== channelId) return false;
+      const start = this.convertTimeToMinutes(s.start_time);
+      const end = this.convertTimeToMinutes(s.end_time);
+      return currentTimeInMinutes >= start && currentTimeInMinutes < end;
+    });
+
+    if (onAirPrograms.length === 0) {
+      this.logger.debug(
+        `🎬 [Manual Premiere] No on-air programs for ${handle} right now`,
+      );
+      return [];
+    }
+
+    const results: Array<{
+      programName: string;
+      videoId: string | null;
+      found: boolean;
+    }> = [];
+
+    for (const schedule of onAirPrograms) {
+      const programName = schedule.program?.name ?? 'Desconocido';
+      const stream = await this.findActivePremiereFromUploads(
+        channelId,
+        handle,
+        programName,
+      );
+
+      if (stream) {
+        const ttl = await getCurrentBlockTTL(
+          channelId,
+          schedules,
+          this.sentryService,
+        );
+        const liveResult = {
+          streams: [stream],
+          primaryVideoId: stream.videoId,
+          streamCount: 1,
+        };
+        const cacheData = createLiveStatusCacheFromStreams(
+          channelId,
+          handle,
+          liveResult,
+          ttl,
+        );
+        await this.redisService.set(
+          `liveStatusByHandle:${handle}`,
+          cacheData,
+          cacheData.ttl,
+        );
+        await this.redisService.del(`videoIdNotFound:${handle}`);
+        this.logger.debug(
+          `🎬 [Manual Premiere] Found and cached ${stream.videoId} for ${programName} on ${handle}`,
+        );
+        results.push({ programName, videoId: stream.videoId, found: true });
+      } else {
+        results.push({ programName, videoId: null, found: false });
+      }
+    }
+
+    return results;
   }
 
   /**


### PR DESCRIPTION
## [1.29.0] - 2026-06-10

### Added
- `is_premiere` boolean field on `Program` entity (default `false`). When enabled, the cron will use a `playlistItems` fallback to detect YouTube premieres (estrenos) that are not returned by `search?eventType=live`.
- `POST /channels/:id/fetch-premiere` endpoint: manually triggers the premiere fallback for all programs currently on-air on the given channel. Bypasses the `is_premiere` flag — intended for backoffice use. Clears not-found Redis flags before fetching and caches any found video ID.
- `is_premiere` support for special programs (weekly overrides of type `create`): the flag is stored in the override's `specialProgram` object and propagated to the virtual program used by the live-fetch flow.

### Fixed
- YouTube premieres (estrenos) are now detected as live streams when `is_premiere` is set on the program. The `search?eventType=live` API does not return premieres, but `videos?part=snippet` correctly reports them as `liveBroadcastContent=live`. The fallback checks the channel's 3 most recent uploads via `playlistItems` (1 quota unit vs 100 for a second search) and uses title-similarity matching to pick the best match when multiple premieres are live simultaneously.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)