### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-03-24 - [N+1 Await Overhead Avoidance in Schedule Enrichment]
+**Learning:** Found sequential `await` patterns inside `enrichSchedules` method of `SchedulesService`. It was using a `for...of` loop over `channelGroups` sequentially awaiting `enrichSchedulesForChannel`. This creates a severe performance bottleneck bounded by N (amount of channel groups).
+**Action:** Always replace sequential asynchronous operations wrapped in `for...of` loops mapped over independent entity lists with `Promise.all(Array.from(map.entries()).map(...))` to ensure optimal concurrency and batch processing.

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -370,16 +370,22 @@ export class SchedulesService {
       }
     }
 
-    // Process each channel group to distribute streams
-    for (const [channelId, channelSchedules] of channelGroups) {
-      const enrichedChannelSchedules = await this.enrichSchedulesForChannel(
-        channelSchedules,
-        currentDay,
-        previousDay,
-        currentNum,
-        liveStatus,
-        batchStreamsResults.get(channelId),
-      );
+    // Process each channel group to distribute streams concurrently
+    const enrichedChannelSchedulesArray = await Promise.all(
+      Array.from(channelGroups.entries()).map(
+        async ([channelId, channelSchedules]) => {
+          return this.enrichSchedulesForChannel(
+            channelSchedules,
+            currentDay,
+            previousDay,
+            currentNum,
+            liveStatus,
+            batchStreamsResults.get(channelId),
+          );
+        },
+      ),
+    );
+    for (const enrichedChannelSchedules of enrichedChannelSchedulesArray) {
       enriched.push(...enrichedChannelSchedules);
     }
 
@@ -501,9 +507,8 @@ export class SchedulesService {
             this.sentryService,
           );
           // Import dynamically to avoid circular dependency
-          const { createLiveStatusCacheFromStreams } = await import(
-            '../youtube/interfaces/live-status-cache.interface'
-          );
+          const { createLiveStatusCacheFromStreams } =
+            await import('../youtube/interfaces/live-status-cache.interface');
           const cacheData = createLiveStatusCacheFromStreams(
             channelId,
             handle,


### PR DESCRIPTION
💡 What: The sequential `for...of` loop awaiting `enrichSchedulesForChannel` for every channel group was replaced with a concurrent `Promise.all` approach using `.map()`.
🎯 Why: In `src/schedules/schedules.service.ts`, the `enrichSchedules` method groups schedules by channel and then processes them one by one. This forces sequential network requests/database checks which degrades performance (N times latency). Executing them concurrently guarantees parallel throughput.
📊 Impact: Expected to significantly reduce latency when hitting the schedules endpoint with live statuses, dropping from an O(N) wait time to O(1) bounded by the slowest API response.
🔬 Measurement: Verified the code structurally respects the sequential output mapping while resolving simultaneously.

---
*PR created automatically by Jules for task [10243235352523925493](https://jules.google.com/task/10243235352523925493) started by @matiasrozenblum*