### PR TITLE
⚡ Bolt: Replace N+1 Redis deletes with single batched delete

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2024-06-15 - [Batched Redis Cache Invalidation]
+**Learning:** Sequential cache invalidation in loops (e.g. `await redisService.del(key)` inside a `for` loop) creates significant N+1 network overhead. Both `ioredis` and `node-redis` natively support bulk deletion by passing an array of keys directly to the `del` command, but doing so requires guarding against empty arrays to prevent throwing client errors.
+**Action:** Always batch cache invalidation requests using `await redisService.del(arrayOfKeys)` when invalidating multiple items, strictly wrapping the call in an `if (arrayOfKeys.length > 0)` condition to preserve safety.

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1183,9 +1183,10 @@ export class WeeklyOverridesService {
       });
 
       // Delete expired overrides
-      for (const key of expiredKeys) {
-        await this.redisService.del(key);
-        cleaned++;
+      // ⚡ Bolt: Replaced sequential await N+1 deletes with a single batched array delete to eliminate Redis network overhead
+      if (expiredKeys.length > 0) {
+        await this.redisService.del(expiredKeys);
+        cleaned += expiredKeys.length;
       }
     }
 


### PR DESCRIPTION
💡 What: Replaced a `for` loop that executed sequential `await this.redisService.del(key)` calls with a single `await this.redisService.del(expiredKeys)` batched operation in `cleanupExpiredOverrides`.

🎯 Why: To eliminate an N+1 network overhead problem where multiple expired cache keys were causing independent round-trips to the Redis server, slowing down the weekly overrides cleanup process.

📊 Impact: Converts O(N) network requests to O(1) for cache invalidation during cleanup, reducing latency, freeing up the event loop, and easing the load on the Redis server when large batches of overrides expire.

🔬 Measurement: Verify by executing the `cleanupExpiredOverrides` function when multiple overrides expire; observe single `DEL` command hitting Redis instead of multiple sequential `DEL`s. Tested using a node simulation of the `del` interface due to environment constraints.

---
*PR created automatically by Jules for task [11210587930734096361](https://jules.google.com/task/11210587930734096361) started by @matiasrozenblum*