### PR TITLE
Release 1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [1.32.0] - 2026-06-20
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [Unreleased]
+
+### Added
+
+- **`POST /programs/bulk`**: crea N programas independientes (uno por canal) en una sola llamada. Acepta `channel_ids: number[]`, todos los campos de `CreateProgramDto` y un array opcional de `schedules` que se replica para cada programa creado.
+- **`POST /weekly-overrides/bulk`**: crea un programa especial (override tipo `create`) en múltiples canales simultáneamente. Acepta `channel_ids: number[]` más todos los campos del override; crea una clave Redis independiente por canal.
+- Nuevo `CreateBulkProgramsDto` con validaciones `class-validator`.
+- Nueva interfaz `BulkWeeklyOverrideDto` en `weekly-overrides.service`.
+
 ## [1.31.0] - 2026-06-16
 
 ### Performance

--- a/src/programs/dto/create-bulk-programs.dto.ts
+++ b/src/programs/dto/create-bulk-programs.dto.ts
@@ -1,0 +1,60 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsBoolean,
+  IsArray,
+  ArrayMinSize,
+  IsInt,
+  ValidateNested,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { CreateScheduleItemDto } from '../../schedules/dto/create-schedule.dto';
+
+export class CreateBulkProgramsDto {
+  @ApiProperty({ description: 'IDs de los canales donde se creará el programa' })
+  @IsArray()
+  @ArrayMinSize(1)
+  @IsInt({ each: true })
+  channel_ids: number[];
+
+  @ApiProperty({ description: 'Nombre del programa' })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({ description: 'Descripción del programa', required: false })
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  logo_url?: string;
+
+  @IsString()
+  @IsOptional()
+  youtube_url?: string;
+
+  @IsOptional()
+  @IsString()
+  style_override?: string;
+
+  @ApiProperty({ required: false })
+  @IsBoolean()
+  @IsOptional()
+  is_visible?: boolean;
+
+  @ApiProperty({ required: false })
+  @IsBoolean()
+  @IsOptional()
+  is_premiere?: boolean;
+
+  @ApiProperty({ required: false, description: 'Horarios a crear para cada programa (mismos para todos los canales)' })
+  @IsArray()
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => CreateScheduleItemDto)
+  schedules?: CreateScheduleItemDto[];
+}

--- a/src/programs/programs.controller.ts
+++ b/src/programs/programs.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { ProgramsService } from './programs.service';
 import { CreateProgramDto } from './dto/create-program.dto';
+import { CreateBulkProgramsDto } from './dto/create-bulk-programs.dto';
 import { Program } from './programs.entity';
 import {
   ApiTags,
@@ -166,6 +167,16 @@ export class ProgramsController {
     @Param('panelistId') panelistId: string,
   ): Promise<void> {
     await this.programsService.removePanelist(Number(id), Number(panelistId));
+  }
+
+  @Post('bulk')
+  @ApiOperation({ summary: 'Create the same program for multiple channels at once' })
+  @ApiResponse({
+    status: 201,
+    description: 'Programs created successfully for all specified channels.',
+  })
+  createBulk(@Body() dto: CreateBulkProgramsDto): Promise<any[]> {
+    return this.programsService.createBulk(dto);
   }
 
   @Post()

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { FindOneOptions, Repository } from 'typeorm';
 import { Program } from './programs.entity';
 import { CreateProgramDto } from './dto/create-program.dto';
+import { CreateBulkProgramsDto } from './dto/create-bulk-programs.dto';
 import { UpdateProgramDto } from './dto/update-program.dto';
 import { Panelist } from '../panelists/panelists.entity';
 import { Channel } from '../channels/channels.entity';
@@ -87,6 +88,80 @@ export class ProgramsService {
       channel_name: savedProgram.channel?.name || null,
       style_override: savedProgram.style_override,
     };
+  }
+
+  async createBulk(dto: CreateBulkProgramsDto): Promise<any[]> {
+    // Validate all channels exist in parallel
+    const channelResults = await Promise.all(
+      dto.channel_ids.map((id) =>
+        this.channelsRepository.findOne({ where: { id } }),
+      ),
+    );
+
+    const missingIds = dto.channel_ids.filter((_, i) => !channelResults[i]);
+    if (missingIds.length > 0) {
+      throw new NotFoundException(
+        `Channels not found: ${missingIds.join(', ')}`,
+      );
+    }
+
+    const channels = channelResults as NonNullable<(typeof channelResults)[0]>[];
+
+    // Batch-create one Program entity per channel
+    const programs = channels.map((channel) =>
+      this.programsRepository.create({
+        name: dto.name,
+        description: dto.description,
+        logo_url: dto.logo_url ?? null,
+        youtube_url: dto.youtube_url ?? null,
+        style_override: dto.style_override ?? null,
+        is_visible: dto.is_visible ?? true,
+        is_premiere: dto.is_premiere ?? false,
+        channel,
+      }),
+    );
+
+    const savedPrograms = await this.programsRepository.save(programs);
+
+    // Create schedules for each program if provided (debounce collapses warm calls)
+    if (dto.schedules && dto.schedules.length > 0) {
+      await Promise.all(
+        savedPrograms.map((program) =>
+          this.schedulesService.createBulk({
+            programId: program.id.toString(),
+            channelId: program.channel!.id.toString(),
+            schedules: dto.schedules!,
+          }),
+        ),
+      );
+    }
+
+    // Clear caches once for all created programs
+    await this.redisService.del(['schedules:week:complete', 'programs:all']);
+    this.schedulesService.debouncedWarmSchedulesCache();
+
+    await this.notifyUtil.notifyAndRevalidate({
+      eventType: 'programs_bulk_created',
+      entity: 'program',
+      entityId: 'bulk',
+      payload: { count: savedPrograms.length },
+      revalidatePaths: ['/'],
+    });
+
+    return savedPrograms.map((p) => ({
+      id: p.id,
+      name: p.name,
+      description: p.description,
+      logo_url: p.logo_url,
+      youtube_url: p.youtube_url,
+      is_live: p.is_live,
+      stream_url: p.stream_url,
+      is_visible: p.is_visible,
+      is_premiere: p.is_premiere,
+      channel_id: p.channel?.id,
+      channel_name: p.channel?.name || null,
+      style_override: p.style_override,
+    }));
   }
 
   async findAll(): Promise<any[]> {

--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -12,6 +12,7 @@ import {
 import {
   WeeklyOverridesService,
   WeeklyOverrideDto,
+  BulkWeeklyOverrideDto,
 } from './weekly-overrides.service';
 import {
   ApiTags,
@@ -29,6 +30,13 @@ export class WeeklyOverridesController {
   constructor(
     private readonly weeklyOverridesService: WeeklyOverridesService,
   ) {}
+
+  @Post('bulk')
+  @ApiOperation({ summary: 'Create a special program override for multiple channels at once' })
+  @ApiResponse({ status: 201, description: 'Bulk overrides created successfully' })
+  async createBulkOverride(@Body() dto: BulkWeeklyOverrideDto) {
+    return this.weeklyOverridesService.createBulk(dto);
+  }
 
   @Post()
   @ApiOperation({ summary: 'Create a weekly override' })

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -43,6 +43,25 @@ export interface WeeklyOverrideDto {
   };
 }
 
+export interface BulkWeeklyOverrideDto {
+  channel_ids: number[];
+  targetWeek: 'current' | 'next';
+  overrideType: 'create';
+  newStartTime: string;
+  newEndTime: string;
+  newDayOfWeek: string;
+  reason?: string;
+  createdBy?: string;
+  panelistIds?: number[];
+  specialProgram: {
+    name: string;
+    description?: string;
+    imageUrl?: string;
+    stream_url?: string;
+    is_premiere?: boolean;
+  };
+}
+
 export interface WeeklyOverride {
   id: string;
   scheduleId?: number; // Optional for special programs or program-level overrides
@@ -1197,6 +1216,143 @@ export class WeeklyOverridesService {
     }
 
     return cleaned;
+  }
+
+  /**
+   * Create a special-program override for multiple channels at once
+   */
+  async createBulk(dto: BulkWeeklyOverrideDto): Promise<WeeklyOverride[]> {
+    if (dto.overrideType !== 'create') {
+      throw new BadRequestException(
+        'Bulk override creation only supports overrideType "create"',
+      );
+    }
+
+    if (!dto.specialProgram?.name) {
+      throw new BadRequestException('Special program name is required');
+    }
+
+    if (!dto.newStartTime || !dto.newEndTime || !dto.newDayOfWeek) {
+      throw new BadRequestException(
+        'Start time, end time, and day of week are required',
+      );
+    }
+
+    // Calculate target week (same logic as createWeeklyOverride)
+    const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
+    let targetWeekStart: dayjs.Dayjs;
+
+    if (dto.targetWeek === 'current') {
+      targetWeekStart = now.startOf('week');
+    } else if (dto.targetWeek === 'next') {
+      targetWeekStart = now.add(1, 'week').startOf('week');
+    } else {
+      throw new BadRequestException(
+        'targetWeek must be either "current" or "next"',
+      );
+    }
+
+    const weekStartDate = targetWeekStart.format('YYYY-MM-DD');
+    const expiresAt = targetWeekStart.add(1, 'week').format('YYYY-MM-DD HH:mm:ss');
+    const secondsUntilExpiry = this.dayjs(expiresAt)
+      .tz('America/Argentina/Buenos_Aires')
+      .diff(now, 'seconds');
+
+    // Fetch panelists once (shared across all channels)
+    let completePanelists: any[] = [];
+    if (dto.panelistIds && dto.panelistIds.length > 0) {
+      const panelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelistIds) },
+      });
+      if (panelists.length !== dto.panelistIds.length) {
+        const foundIds = panelists.map((p) => p.id);
+        const missingIds = dto.panelistIds.filter((id) => !foundIds.includes(id));
+        throw new NotFoundException(
+          `Panelists with IDs ${missingIds.join(', ')} not found`,
+        );
+      }
+      completePanelists = panelists;
+    }
+
+    // Fetch all channel objects in one query
+    const channelRows = await this.dataSource.query(
+      `SELECT id, name, handle, youtube_channel_id, logo_url, description, "order", is_visible
+       FROM channel WHERE id = ANY($1)`,
+      [dto.channel_ids],
+    );
+
+    const channelMap = new Map<number, any>(
+      channelRows.map((c: any) => [c.id, c]),
+    );
+
+    const missingChannelIds = dto.channel_ids.filter((id) => !channelMap.has(id));
+    if (missingChannelIds.length > 0) {
+      throw new NotFoundException(
+        `Channels not found: ${missingChannelIds.join(', ')}`,
+      );
+    }
+
+    const name = dto.specialProgram.name.replace(/\s+/g, '_').toLowerCase();
+    const dayOfWeek = dto.newDayOfWeek.toLowerCase();
+
+    const created: WeeklyOverride[] = [];
+
+    for (const channelId of dto.channel_ids) {
+      const overrideId = `special_channel_${channelId}_${name}_${dayOfWeek}_${weekStartDate}`;
+
+      // Skip if already exists
+      const existing = await this.getWeeklyOverride(overrideId);
+      if (existing) {
+        this.logger.warn(
+          `[BULK-OVERRIDE] Override ${overrideId} already exists, skipping`,
+        );
+        continue;
+      }
+
+      const channel = channelMap.get(channelId);
+      const override: WeeklyOverride = {
+        id: overrideId,
+        weekStartDate,
+        overrideType: 'create',
+        newStartTime: dto.newStartTime,
+        newEndTime: dto.newEndTime,
+        newDayOfWeek: dayOfWeek,
+        reason: dto.reason,
+        createdBy: dto.createdBy,
+        expiresAt,
+        createdAt: new Date(),
+        panelistIds: dto.panelistIds,
+        panelists: completePanelists,
+        specialProgram: {
+          ...dto.specialProgram,
+          channelId,
+          channel,
+        },
+      };
+
+      await this.redisService.set(
+        `weekly_override:${overrideId}`,
+        override,
+        secondsUntilExpiry,
+      );
+
+      created.push(override);
+    }
+
+    // Clear caches once for all created overrides
+    await this.redisService.del('schedules:week:complete');
+    await this.updateWeeklyCacheForWeek(weekStartDate);
+    this.schedulesService?.debouncedWarmSchedulesCache?.();
+
+    await this.notifyUtil.notifyAndRevalidate({
+      eventType: 'overrides_bulk_created',
+      entity: 'override',
+      entityId: 'bulk',
+      payload: { count: created.length },
+      revalidatePaths: ['/'],
+    });
+
+    return created;
   }
 
   /**


### PR DESCRIPTION
## [1.32.0] - 2026-06-20

### Added

- **`POST /programs/bulk`**: crea N programas independientes (uno por canal) en una sola llamada. Acepta `channel_ids: number[]`, todos los campos de `CreateProgramDto` y un array opcional de `schedules` que se replica para cada programa creado.
- **`POST /weekly-overrides/bulk`**: crea un programa especial (override tipo `create`) en múltiples canales simultáneamente. Acepta `channel_ids: number[]` más todos los campos del override; crea una clave Redis independiente por canal.
- Nuevo `CreateBulkProgramsDto` con validaciones `class-validator`.
- Nueva interfaz `BulkWeeklyOverrideDto` en `weekly-overrides.service`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)