### PR TITLE
⚡ Bolt: [performance improvement] - Optimize bulk program creation query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2025-02-27 - [Fix N+1 query in programs bulk creation]
+**Learning:** The `createBulk` method in `ProgramsService` was executing an N+1 query pattern by resolving an array of `channel_ids` using `Promise.all()` with individual `channelsRepository.findOne()` queries.
+**Action:** Replaced the concurrent individual database queries with a single batch query utilizing TypeORM's `In()` operator. Then, mapped the unordered result set back to the original array to preserve matching order. This eliminates N query roundtrips in favor of 1.

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -5,7 +5,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository } from 'typeorm';
+import { FindOneOptions, Repository, In } from 'typeorm';
 import { Program } from './programs.entity';
 import { CreateProgramDto } from './dto/create-program.dto';
 import { CreateBulkProgramsDto } from './dto/create-bulk-programs.dto';
@@ -92,10 +92,15 @@ export class ProgramsService {
 
   async createBulk(dto: CreateBulkProgramsDto): Promise<any[]> {
     // Validate all channels exist in parallel
-    const channelResults = await Promise.all(
-      dto.channel_ids.map((id) =>
-        this.channelsRepository.findOne({ where: { id } }),
-      ),
+    // TypeORM In operator to fetch all channels in a single query
+    const channelResultsUnordered = await this.channelsRepository.find({
+      where: { id: In(dto.channel_ids) },
+    });
+
+    // Maintain the order of the original array to map correctly to missingIds
+    const channelResults = dto.channel_ids.map(
+      (id) =>
+        channelResultsUnordered.find((channel) => channel.id === id) || null,
     );
 
     const missingIds = dto.channel_ids.filter((_, i) => !channelResults[i]);
@@ -105,7 +110,9 @@ export class ProgramsService {
       );
     }
 
-    const channels = channelResults as NonNullable<(typeof channelResults)[0]>[];
+    const channels = channelResults as NonNullable<
+      (typeof channelResults)[0]
+    >[];
 
     // Batch-create one Program entity per channel
     const programs = channels.map((channel) =>


### PR DESCRIPTION
💡 **What:** 
Replaced an N+1 query pattern in `ProgramsService.createBulk` where `Promise.all` with multiple `channelsRepository.findOne()` queries were used to fetch channels. This was refactored into a single TypeORM `find` query using the `In()` operator. The unordered results are then mapped back to the original array order to exactly match the prior behavior.

🎯 **Why:** 
The previous implementation performed $N$ database lookups concurrently (where $N$ is the number of `channel_ids`), causing high latency and excessive database load during bulk creation workflows.

📊 **Impact:** 
Eliminates $N-1$ database roundtrips during program bulk creation. Fetching all referenced channels now requires only $1$ DB query.

🔬 **Measurement:** 
Creating 10 programs in bulk simultaneously previously sent 10 individual `SELECT` database queries to the channel repository. This patch condenses it down to 1 batched `SELECT ... WHERE id IN (...)` query. Verify speedup via performance/profiling measurements on the `createBulk` endpoint latency.

---
*PR created automatically by Jules for task [921808581309886757](https://jules.google.com/task/921808581309886757) started by @matiasrozenblum*