### PR TITLE
Release 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
 ### Added
 
+- **Programas linkeados (`link_group_id`)**: nueva columna UUID en la entidad `program` que agrupa programas que se transmiten simultáneamente en distintos canales. Migración `AddLinkGroupIdToPrograms` incluida.
+- **Propagación de overrides a programas linkeados**: al crear o actualizar un `weekly-override` (tipos `cancel`, `time_change`, `reschedule`) sobre un programa con `link_group_id`, el backend replica automáticamente el override a todos los programas del mismo grupo.
+- **Detección automática de conflictos de grilla**: tras aplicar un override, se detectan los programas con horario superpuesto en los canales afectados y se devuelven como array `conflicts` en la respuesta de `POST /weekly-overrides` y `POST /weekly-overrides/bulk`.
+- **`POST /weekly-overrides/resolve-conflicts`**: nuevo endpoint para aplicar resoluciones (`cancel`, `time_change`, `keep`) sobre los conflictos detectados.
+
+### Fixed
+
+- La detección de conflictos ahora se activa correctamente para overrides de tipo `create` y para el endpoint `POST /weekly-overrides/bulk`.
+- Los programas con `is_visible = false` ya no se incluyen en la lista de conflictos detectados.
+
+---
+
+## [1.32.0] - 2026-06-20
+
+### Added
+
 - **`POST /programs/bulk`**: crea N programas independientes (uno por canal) en una sola llamada. Acepta `channel_ids: number[]`, todos los campos de `CreateProgramDto` y un array opcional de `schedules` que se replica para cada programa creado.
 - **`POST /weekly-overrides/bulk`**: crea un programa especial (override tipo `create`) en múltiples canales simultáneamente. Acepta `channel_ids: number[]` más todos los campos del override; crea una clave Redis independiente por canal.
 - Nuevo `CreateBulkProgramsDto` con validaciones `class-validator`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [1.33.0] - 2026-06-23
 
 ### Added
 

--- a/src/migrations/1782250703030-AddLinkGroupIdToPrograms.ts
+++ b/src/migrations/1782250703030-AddLinkGroupIdToPrograms.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddLinkGroupIdToPrograms1782250703030 implements MigrationInterface {
+    name = 'AddLinkGroupIdToPrograms1782250703030'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "program" ADD "link_group_id" character varying`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "program" DROP COLUMN "link_group_id"`);
+    }
+}

--- a/src/programs/dto/create-bulk-programs.dto.ts
+++ b/src/programs/dto/create-bulk-programs.dto.ts
@@ -57,4 +57,10 @@ export class CreateBulkProgramsDto {
   @ValidateNested({ each: true })
   @Type(() => CreateScheduleItemDto)
   schedules?: CreateScheduleItemDto[];
+
+  @ApiProperty({ required: false, description: 'IDs de panelistas a asignar a todos los programas creados' })
+  @IsArray()
+  @IsOptional()
+  @IsInt({ each: true })
+  panelist_ids?: number[];
 }

--- a/src/programs/programs.controller.ts
+++ b/src/programs/programs.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Delete,
   Patch,
+  Query,
   UseGuards,
   NotFoundException,
   Request,
@@ -210,7 +211,10 @@ export class ProgramsController {
     description: 'The program has been successfully deleted.',
   })
   @ApiResponse({ status: 404, description: 'Program not found.' })
-  remove(@Param('id') id: string): Promise<void> {
-    return this.programsService.remove(Number(id));
+  remove(
+    @Param('id') id: string,
+    @Query('deleteLinked') deleteLinked?: string,
+  ): Promise<void> {
+    return this.programsService.remove(Number(id), deleteLinked === 'true');
   }
 }

--- a/src/programs/programs.entity.ts
+++ b/src/programs/programs.entity.ts
@@ -61,4 +61,7 @@ export class Program {
 
   @Column({ type: 'boolean', default: false })
   is_premiere: boolean;
+
+  @Column({ type: 'varchar', nullable: true })
+  link_group_id: string | null;
 }

--- a/src/programs/programs.module.ts
+++ b/src/programs/programs.module.ts
@@ -5,13 +5,14 @@ import { ProgramsService } from './programs.service';
 import { Program } from './programs.entity';
 import { Panelist } from '../panelists/panelists.entity';
 import { Channel } from '../channels/channels.entity';
+import { Schedule } from '../schedules/schedules.entity';
 import { RedisModule } from '../redis/redis.module';
 import { UsersModule } from '../users/users.module';
 import { SchedulesModule } from '../schedules/schedules.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Program, Panelist, Channel]),
+    TypeOrmModule.forFeature([Program, Panelist, Channel, Schedule]),
     RedisModule,
     UsersModule,
     forwardRef(() => SchedulesModule),

--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -7,6 +7,7 @@ import { Repository } from 'typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { CreateProgramDto } from './dto/create-program.dto';
 import { Channel } from '../channels/channels.entity';
+import { Schedule } from '../schedules/schedules.entity';
 import { RedisService } from '../redis/redis.service';
 import { SchedulesService } from '../schedules/schedules.service';
 import { WeeklyOverridesService } from '../schedules/weekly-overrides.service';
@@ -62,6 +63,10 @@ describe('ProgramsService', () => {
     youtube_url: 'https://youtube.com/test',
     is_live: false,
     stream_url: null,
+    is_visible: true,
+    is_premiere: false,
+    style_override: null,
+    link_group_id: null,
   };
 
   const mockProgramResponse = {
@@ -73,6 +78,10 @@ describe('ProgramsService', () => {
     youtube_url: 'https://youtube.com/test',
     is_live: false,
     stream_url: null,
+    is_visible: true,
+    is_premiere: false,
+    style_override: null,
+    link_group_id: null,
     channel_id: 1,
     channel_name: 'Luzu TV',
   };
@@ -139,6 +148,16 @@ describe('ProgramsService', () => {
         {
           provide: getRepositoryToken(Channel),
           useValue: channelRepository,
+        },
+        {
+          provide: getRepositoryToken(Schedule),
+          useValue: {
+            find: jest.fn().mockResolvedValue([]),
+            findOne: jest.fn().mockResolvedValue(null),
+            save: jest.fn(),
+            create: jest.fn(),
+            delete: jest.fn(),
+          },
         },
         {
           provide: RedisService,
@@ -235,9 +254,12 @@ describe('ProgramsService', () => {
       youtube_url: 'https://youtube.com/updated',
       is_live: false,
       stream_url: null,
+      is_visible: true,
+      is_premiere: false,
+      style_override: null,
+      link_group_id: null,
       channel_id: 1,
       channel_name: 'Luzu TV',
-      style_override: undefined,
     });
     expect(programRepository.createQueryBuilder).toHaveBeenCalledWith(
       'program',
@@ -301,9 +323,12 @@ describe('ProgramsService', () => {
       youtube_url: 'https://youtube.com/test',
       is_live: false,
       stream_url: null,
+      is_visible: undefined,
+      is_premiere: undefined,
+      style_override: undefined,
+      link_group_id: null,
       channel_id: 2,
       channel_name: 'New Channel',
-      style_override: undefined,
     });
 
     expect(channelRepository.findOne).toHaveBeenCalledWith({

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -6,12 +6,14 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { FindOneOptions, Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
 import { Program } from './programs.entity';
 import { CreateProgramDto } from './dto/create-program.dto';
 import { CreateBulkProgramsDto } from './dto/create-bulk-programs.dto';
 import { UpdateProgramDto } from './dto/update-program.dto';
 import { Panelist } from '../panelists/panelists.entity';
 import { Channel } from '../channels/channels.entity';
+import { Schedule } from '../schedules/schedules.entity';
 import { RedisService } from '../redis/redis.service';
 import { WeeklyOverridesService } from '../schedules/weekly-overrides.service';
 import { SchedulesService } from '../schedules/schedules.service';
@@ -32,6 +34,8 @@ export class ProgramsService {
     private panelistsRepository: Repository<Panelist>,
     @InjectRepository(Channel)
     private channelsRepository: Repository<Channel>,
+    @InjectRepository(Schedule)
+    private schedulesRepository: Repository<Schedule>,
     private redisService: RedisService,
     private weeklyOverridesService: WeeklyOverridesService,
     @Inject(forwardRef(() => SchedulesService))
@@ -87,6 +91,7 @@ export class ProgramsService {
       channel_id: savedProgram.channel?.id,
       channel_name: savedProgram.channel?.name || null,
       style_override: savedProgram.style_override,
+      link_group_id: savedProgram.link_group_id ?? null,
     };
   }
 
@@ -107,6 +112,9 @@ export class ProgramsService {
 
     const channels = channelResults as NonNullable<(typeof channelResults)[0]>[];
 
+    // Generate a shared UUID when creating for multiple channels so programs are linked
+    const linkGroupId = dto.channel_ids.length > 1 ? randomUUID() : null;
+
     // Batch-create one Program entity per channel
     const programs = channels.map((channel) =>
       this.programsRepository.create({
@@ -117,13 +125,30 @@ export class ProgramsService {
         style_override: dto.style_override ?? null,
         is_visible: dto.is_visible ?? true,
         is_premiere: dto.is_premiere ?? false,
+        link_group_id: linkGroupId,
         channel,
       }),
     );
 
     const savedPrograms = await this.programsRepository.save(programs);
 
-    // Create schedules for each program if provided (debounce collapses warm calls)
+    // Assign panelists to all created programs if provided
+    if (dto.panelist_ids && dto.panelist_ids.length > 0) {
+      const panelists = await Promise.all(
+        dto.panelist_ids.map((pid) =>
+          this.panelistsRepository.findOne({ where: { id: pid } }),
+        ),
+      );
+      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      if (validPanelists.length > 0) {
+        for (const program of savedPrograms) {
+          program.panelists = validPanelists;
+        }
+        await this.programsRepository.save(savedPrograms);
+      }
+    }
+
+    // Create schedules for each program if provided (skip link propagation — all programs handled here)
     if (dto.schedules && dto.schedules.length > 0) {
       await Promise.all(
         savedPrograms.map((program) =>
@@ -131,6 +156,7 @@ export class ProgramsService {
             programId: program.id.toString(),
             channelId: program.channel!.id.toString(),
             schedules: dto.schedules!,
+            skipLinkPropagation: true,
           }),
         ),
       );
@@ -161,6 +187,7 @@ export class ProgramsService {
       channel_id: p.channel?.id,
       channel_name: p.channel?.name || null,
       style_override: p.style_override,
+      link_group_id: p.link_group_id ?? null,
     }));
   }
 
@@ -189,6 +216,7 @@ export class ProgramsService {
       channel_id: program.channel?.id,
       channel_name: program.channel?.name || null,
       style_override: program.style_override,
+      link_group_id: program.link_group_id ?? null,
     }));
     await this.redisService.set(cacheKey, result, 300);
     return result;
@@ -223,6 +251,7 @@ export class ProgramsService {
       channel_id: program.channel?.id,
       channel_name: program.channel?.name || null,
       style_override: program.style_override,
+      link_group_id: program.link_group_id ?? null,
     };
     await this.redisService.set(cacheKey, result, 300);
     return result;
@@ -242,15 +271,32 @@ export class ProgramsService {
         );
       }
       program.channel = newChannel;
-      // Remove channel_id from DTO to avoid conflicts with Object.assign
       const { channel_id, ...updateData } = updateProgramDto;
       Object.assign(program, updateData);
     } else {
-      // Update other fields normally if no channel_id change
       Object.assign(program, updateProgramDto);
     }
 
     const updatedProgram = await this.programsRepository.save(program);
+
+    // Propagate metadata changes to all linked programs (never propagate channel_id)
+    if (updatedProgram.link_group_id) {
+      const { channel_id: _cid, ...fieldsToPropagate } = updateProgramDto;
+      const linkedPrograms = await this.programsRepository.find({
+        where: { link_group_id: updatedProgram.link_group_id },
+        relations: ['channel'],
+      });
+      const othersToUpdate = linkedPrograms.filter((p) => p.id !== id);
+      if (othersToUpdate.length > 0) {
+        for (const linked of othersToUpdate) {
+          Object.assign(linked, fieldsToPropagate);
+        }
+        await this.programsRepository.save(othersToUpdate);
+        await this.redisService.del(
+          othersToUpdate.map((p) => `programs:${p.id}`),
+        );
+      }
+    }
 
     // Clear caches
     await this.redisService.del([
@@ -285,11 +331,11 @@ export class ProgramsService {
       channel_id: updatedProgram.channel?.id,
       channel_name: updatedProgram.channel?.name || null,
       style_override: updatedProgram.style_override,
+      link_group_id: updatedProgram.link_group_id ?? null,
     };
   }
 
-  async remove(id: number): Promise<void> {
-    // Get all schedule IDs for this program before deleting
+  async remove(id: number, deleteLinked = false): Promise<void> {
     const program = await this.programsRepository.findOne({
       where: { id },
       relations: ['schedules'],
@@ -297,13 +343,22 @@ export class ProgramsService {
     if (!program) {
       throw new NotFoundException(`Program with ID ${id} not found`);
     }
+
+    // If deleteLinked, delete every program in the group (including this one)
+    if (deleteLinked && program.link_group_id) {
+      const group = await this.programsRepository.find({
+        where: { link_group_id: program.link_group_id },
+        select: ['id'],
+      });
+      await Promise.all(group.map((p) => this.remove(p.id, false)));
+      return;
+    }
+
     const scheduleIds = (program.schedules || []).map((s) => s.id);
-    // Delete all related weekly overrides
     await this.weeklyOverridesService.deleteOverridesForProgram(
       id,
       scheduleIds,
     );
-    // Delete the program (cascades schedules, panelists, etc.)
     const result = await this.programsRepository.delete(id);
     if (result.affected === 0) {
       throw new NotFoundException(`Program with ID ${id} not found`);
@@ -353,13 +408,27 @@ export class ProgramsService {
       throw new NotFoundException(`Panelist with ID ${panelistId} not found`);
     }
 
-    if (!program.panelists) {
-      program.panelists = [];
-    }
-
+    if (!program.panelists) program.panelists = [];
     if (!program.panelists.some((p) => p.id === panelist.id)) {
       program.panelists.push(panelist);
       await this.programsRepository.save(program);
+    }
+
+    // Propagate to linked programs
+    if (program.link_group_id) {
+      const linked = await this.programsRepository.find({
+        where: { link_group_id: program.link_group_id },
+        relations: ['panelists'],
+      });
+      const others = linked.filter((p) => p.id !== programId);
+      for (const other of others) {
+        if (!other.panelists) other.panelists = [];
+        if (!other.panelists.some((p) => p.id === panelistId)) {
+          other.panelists.push(panelist);
+          await this.programsRepository.save(other);
+          await this.redisService.del([`programs:${other.id}`]);
+        }
+      }
     }
 
     // Clear caches
@@ -388,6 +457,22 @@ export class ProgramsService {
     if (program.panelists) {
       program.panelists = program.panelists.filter((p) => p.id !== panelistId);
       await this.programsRepository.save(program);
+    }
+
+    // Propagate to linked programs
+    if (program.link_group_id) {
+      const linked = await this.programsRepository.find({
+        where: { link_group_id: program.link_group_id },
+        relations: ['panelists'],
+      });
+      const others = linked.filter((p) => p.id !== programId);
+      for (const other of others) {
+        if (other.panelists) {
+          other.panelists = other.panelists.filter((p) => p.id !== panelistId);
+          await this.programsRepository.save(other);
+          await this.redisService.del([`programs:${other.id}`]);
+        }
+      }
     }
 
     // Clear caches

--- a/src/schedules/dto/create-schedule.dto.ts
+++ b/src/schedules/dto/create-schedule.dto.ts
@@ -91,4 +91,6 @@ export class CreateBulkSchedulesDto {
   @ValidateNested({ each: true })
   @Type(() => CreateScheduleItemDto)
   schedules: CreateScheduleItemDto[];
+
+  skipLinkPropagation?: boolean;
 }

--- a/src/schedules/schedules-logging.spec.ts
+++ b/src/schedules/schedules-logging.spec.ts
@@ -52,6 +52,7 @@ describe('SchedulesService Logging Improvements', () => {
       style_override: null,
       is_visible: true,
       is_premiere: false,
+      link_group_id: null,
     },
   };
 

--- a/src/schedules/schedules.service.spec.ts
+++ b/src/schedules/schedules.service.spec.ts
@@ -154,6 +154,9 @@ describe('SchedulesService', () => {
     is_live: false,
     stream_url: '',
     is_visible: true,
+    is_premiere: false,
+    style_override: null,
+    link_group_id: null,
     channel: mockChannel,
     panelists: [],
     schedules: [],
@@ -898,6 +901,7 @@ describe('SchedulesService', () => {
             style_override: null,
             is_visible: true,
             is_premiere: false,
+            link_group_id: null,
             channel: {
               id: 1,
               name: 'Vorterix',

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -879,6 +879,9 @@ export class SchedulesService {
     });
     const saved = await this.schedulesRepository.save(schedule);
 
+    // Propagate schedule changes to linked programs
+    await this.syncSchedulesToLinkedPrograms(+dto.programId);
+
     // Clear unified cache
     await this.redisService.del('schedules:week:complete');
 
@@ -899,6 +902,7 @@ export class SchedulesService {
 
   async update(id: string, dto: UpdateScheduleDto): Promise<Schedule> {
     const schedule = await this.findOne(id);
+    const programId = +schedule.program_id;
     if (dto.dayOfWeek !== undefined) schedule.day_of_week = dto.dayOfWeek;
     if (dto.startTime) schedule.start_time = dto.startTime;
     if (dto.endTime) schedule.end_time = dto.endTime;
@@ -909,6 +913,9 @@ export class SchedulesService {
     if (dto.specificDate !== undefined)
       schedule.specific_date = dto.specificDate;
     const updated = await this.schedulesRepository.save(schedule);
+
+    // Propagate schedule changes to linked programs
+    await this.syncSchedulesToLinkedPrograms(programId);
 
     // Clear unified cache
     await this.redisService.del('schedules:week:complete');
@@ -930,8 +937,17 @@ export class SchedulesService {
   }
 
   async remove(id: string): Promise<boolean> {
+    // Load before delete to capture program_id for link propagation
+    const schedule = await this.schedulesRepository.findOne({ where: { id: +id } });
+    const programId = schedule ? +schedule.program_id : null;
+
     const result = await this.schedulesRepository.delete(id);
     if ((result?.affected ?? 0) > 0) {
+      // Propagate schedule deletion to linked programs
+      if (programId !== null) {
+        await this.syncSchedulesToLinkedPrograms(programId);
+      }
+
       // Clear unified cache (consistent with all other mutation methods)
       await this.redisService.del('schedules:week:complete');
 
@@ -1026,6 +1042,11 @@ export class SchedulesService {
 
     const savedSchedules = await this.schedulesRepository.save(schedules);
 
+    // Propagate to linked programs unless explicitly skipped (e.g. during linked-program bulk creation)
+    if (!dto.skipLinkPropagation) {
+      await this.syncSchedulesToLinkedPrograms(+dto.programId);
+    }
+
     // Clear unified cache
     await this.redisService.del('schedules:week:complete');
 
@@ -1049,6 +1070,48 @@ export class SchedulesService {
    * Used for program start detection to validate cached video IDs
    * OPTIMIZED: Uses cached schedules instead of database query
    */
+  /**
+   * After any schedule mutation on a program, copy its current schedules to all
+   * other programs that share the same link_group_id (full replace).
+   */
+  private async syncSchedulesToLinkedPrograms(programId: number): Promise<void> {
+    const program = await this.programsRepository.findOne({
+      where: { id: programId },
+      select: ['id', 'link_group_id'],
+    });
+    if (!program?.link_group_id) return;
+
+    const linkedPrograms = await this.programsRepository.find({
+      where: { link_group_id: program.link_group_id },
+      select: ['id'],
+    });
+    const others = linkedPrograms.filter((p) => p.id !== programId);
+    if (others.length === 0) return;
+
+    // Load current schedules of the source program
+    const sourceSchedules = await this.schedulesRepository.find({
+      where: { program_id: programId.toString() },
+    });
+
+    for (const other of others) {
+      await this.schedulesRepository.delete({ program_id: other.id.toString() });
+      if (sourceSchedules.length > 0) {
+        const copies = sourceSchedules.map((s) =>
+          this.schedulesRepository.create({
+            day_of_week: s.day_of_week,
+            start_time: s.start_time,
+            end_time: s.end_time,
+            schedule_type: s.schedule_type,
+            week_number_in_month: s.week_number_in_month,
+            specific_date: s.specific_date,
+            program_id: other.id.toString(),
+          }),
+        );
+        await this.schedulesRepository.save(copies);
+      }
+    }
+  }
+
   // ─── Monthly schedule helpers ──────────────────────────────────────────────
 
   private getDayDateInCurrentWeek(dayOfWeek: string): dayjs.Dayjs {

--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -13,6 +13,7 @@ import {
   WeeklyOverridesService,
   WeeklyOverrideDto,
   BulkWeeklyOverrideDto,
+  ResolveConflictsDto,
 } from './weekly-overrides.service';
 import {
   ApiTags,
@@ -36,6 +37,13 @@ export class WeeklyOverridesController {
   @ApiResponse({ status: 201, description: 'Bulk overrides created successfully' })
   async createBulkOverride(@Body() dto: BulkWeeklyOverrideDto) {
     return this.weeklyOverridesService.createBulk(dto);
+  }
+
+  @Post('resolve-conflicts')
+  @ApiOperation({ summary: 'Resolve schedule conflicts after a linked-program override' })
+  @ApiResponse({ status: 201, description: 'Conflicts resolved successfully' })
+  async resolveConflicts(@Body() dto: ResolveConflictsDto) {
+    return this.weeklyOverridesService.resolveConflicts(dto);
   }
 
   @Post()

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -71,7 +71,7 @@ describe('WeeklyOverridesService', () => {
         {
           provide: DataSource,
           useValue: {
-            query: jest.fn(),
+            query: jest.fn().mockResolvedValue([]),
           },
         },
         {
@@ -931,6 +931,342 @@ describe('WeeklyOverridesService', () => {
 
       expect(result).toBe(0);
       expect(redisService.del).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('linked programs — propagateOverrideToLinkedPrograms', () => {
+    it('should return empty array when program has no link_group_id', async () => {
+      jest
+        .spyOn(dataSource, 'query')
+        .mockResolvedValueOnce([{ link_group_id: null }]); // SELECT link_group_id FROM program
+
+      const dto: WeeklyOverrideDto = {
+        programId: 1,
+        targetWeek: 'current',
+        overrideType: 'cancel',
+      };
+
+      // programId validation: needs a schedule belonging to programId=1
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.linkedOverrides).toEqual([]);
+    });
+
+    it('should propagate cancel override to all programs in the link group', async () => {
+      const linkGroupId = 'group-uuid-123';
+      jest
+        .spyOn(dataSource, 'query')
+        // propagateOverrideToLinkedPrograms: SELECT link_group_id FROM program WHERE id = 1
+        .mockResolvedValueOnce([{ link_group_id: linkGroupId }])
+        // SELECT id FROM program WHERE link_group_id = ... AND id != 1
+        .mockResolvedValueOnce([{ id: 2 }, { id: 3 }])
+        // SELECT id FROM schedule WHERE program_id = '2' AND day_of_week = ...
+        .mockResolvedValueOnce([{ id: 20 }])
+        // SELECT id FROM schedule WHERE program_id = '3' AND day_of_week = ...
+        .mockResolvedValueOnce([{ id: 30 }]);
+
+      const dto: WeeklyOverrideDto = {
+        programId: 1,
+        targetWeek: 'current',
+        overrideType: 'cancel',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      // Two linked programs get propagated overrides
+      expect(result.linkedOverrides).toHaveLength(2);
+      expect(result.linkedOverrides[0].overrideType).toBe('cancel');
+      expect(result.linkedOverrides[1].overrideType).toBe('cancel');
+    });
+
+    it('should not propagate to itself — only to other programs in the group', async () => {
+      const linkGroupId = 'group-uuid-self';
+      jest
+        .spyOn(dataSource, 'query')
+        .mockResolvedValueOnce([{ link_group_id: linkGroupId }])
+        .mockResolvedValueOnce([]); // No OTHER programs in group
+
+      const dto: WeeklyOverrideDto = {
+        programId: 5,
+        targetWeek: 'current',
+        overrideType: 'cancel',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue({ ...mockSchedule, program: { id: 5 } } as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.linkedOverrides).toEqual([]);
+    });
+  });
+
+  describe('linked programs — detectConflictsForLinkedChannels', () => {
+    it('should return empty conflicts when no overlapping schedules exist', async () => {
+      jest
+        .spyOn(dataSource, 'query')
+        // schedule → program_id lookup
+        .mockResolvedValueOnce([{ program_id: 1, day_of_week: 'monday' }])
+        // propagation: link_group_id lookup
+        .mockResolvedValueOnce([{ link_group_id: null }])
+        // detectConflictsForLinkedChannels: program info
+        .mockResolvedValueOnce([
+          { id: 1, link_group_id: null, channel_id: 1, channel_name: 'Canal 1' },
+        ])
+        // detectConflictsForChannel SQL: no overlapping rows
+        .mockResolvedValueOnce([]);
+
+      const dto: WeeklyOverrideDto = {
+        scheduleId: 1,
+        targetWeek: 'current',
+        overrideType: 'time_change',
+        newStartTime: '15:00',
+        newEndTime: '17:00',
+        newDayOfWeek: 'monday',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.conflicts).toEqual([]);
+    });
+
+    it('should return conflicts when overlapping schedules are detected', async () => {
+      jest
+        .spyOn(dataSource, 'query')
+        // schedule → program_id/day_of_week
+        .mockResolvedValueOnce([{ program_id: 1, day_of_week: 'monday' }])
+        // propagation: link_group_id
+        .mockResolvedValueOnce([{ link_group_id: null }])
+        // detectConflictsForLinkedChannels: program info
+        .mockResolvedValueOnce([
+          { id: 1, link_group_id: null, channel_id: 1, channel_name: 'Canal Test' },
+        ])
+        // detectConflictsForChannel: overlapping schedule rows
+        .mockResolvedValueOnce([
+          {
+            schedule_id: 99,
+            day_of_week: 'monday',
+            start_time: '14:30',
+            end_time: '16:00',
+            program_id: 42,
+            program_name: 'Programa Solapado',
+          },
+        ])
+        // existing override check for the conflict (redis.get returns null → no existing override)
+        .mockResolvedValue([]);
+
+      const dto: WeeklyOverrideDto = {
+        scheduleId: 1,
+        targetWeek: 'current',
+        overrideType: 'time_change',
+        newStartTime: '15:00',
+        newEndTime: '17:00',
+        newDayOfWeek: 'monday',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].programName).toBe('Programa Solapado');
+      expect(result.conflicts[0].channelName).toBe('Canal Test');
+      expect(result.conflicts[0].dayOfWeek).toBe('monday');
+    });
+  });
+
+  describe('resolveConflicts', () => {
+    it('should skip resolutions with action keep', async () => {
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+      jest.spyOn(redisService, 'del').mockResolvedValue(undefined);
+
+      const result = await service.resolveConflicts({
+        targetWeek: 'current',
+        resolutions: [
+          {
+            programId: 1,
+            channelId: 1,
+            dayOfWeek: 'monday',
+            weekStartDate: '2026-06-23',
+            action: 'keep',
+          },
+        ],
+      });
+
+      expect(result.skipped).toBe(1);
+      expect(result.resolved).toBe(0);
+      // No override written (only the live_notification key is set for the summary event)
+      const overrideSetCalls = (redisService.set as jest.Mock).mock.calls.filter(
+        (args) => !String(args[0]).startsWith('live_notification:'),
+      );
+      expect(overrideSetCalls).toHaveLength(0);
+    });
+
+    it('should create a cancel override for action cancel', async () => {
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+      jest.spyOn(redisService, 'del').mockResolvedValue(undefined);
+
+      const result = await service.resolveConflicts({
+        targetWeek: 'current',
+        resolutions: [
+          {
+            programId: 10,
+            channelId: 1,
+            dayOfWeek: 'monday',
+            weekStartDate: '2026-06-23',
+            action: 'cancel',
+          },
+        ],
+      });
+
+      expect(result.resolved).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining('weekly_override:'),
+        expect.objectContaining({ overrideType: 'cancel' }),
+        expect.any(Number),
+      );
+    });
+
+    it('should create a time_change override for action reschedule', async () => {
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+      jest.spyOn(redisService, 'del').mockResolvedValue(undefined);
+
+      const result = await service.resolveConflicts({
+        targetWeek: 'current',
+        resolutions: [
+          {
+            programId: 10,
+            channelId: 1,
+            dayOfWeek: 'monday',
+            weekStartDate: '2026-06-23',
+            action: 'reschedule',
+            newStartTime: '18:00',
+            newEndTime: '19:00',
+          },
+        ],
+      });
+
+      expect(result.resolved).toBe(1);
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining('weekly_override:'),
+        expect.objectContaining({
+          overrideType: 'time_change',
+          newStartTime: '18:00',
+          newEndTime: '19:00',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should handle mixed resolutions correctly', async () => {
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+      jest.spyOn(redisService, 'del').mockResolvedValue(undefined);
+
+      const result = await service.resolveConflicts({
+        targetWeek: 'current',
+        resolutions: [
+          {
+            programId: 1,
+            channelId: 1,
+            dayOfWeek: 'monday',
+            weekStartDate: '2026-06-23',
+            action: 'keep',
+          },
+          {
+            programId: 2,
+            channelId: 2,
+            dayOfWeek: 'monday',
+            weekStartDate: '2026-06-23',
+            action: 'cancel',
+          },
+          {
+            programId: 3,
+            channelId: 3,
+            dayOfWeek: 'monday',
+            weekStartDate: '2026-06-23',
+            action: 'reschedule',
+            newStartTime: '20:00',
+            newEndTime: '21:00',
+          },
+        ],
+      });
+
+      expect(result.resolved).toBe(2);
+      expect(result.skipped).toBe(1);
+    });
+  });
+
+  describe('createWeeklyOverride — response shape', () => {
+    it('should always return linkedOverrides and conflicts arrays', async () => {
+      const dto: WeeklyOverrideDto = {
+        scheduleId: 1,
+        targetWeek: 'current',
+        overrideType: 'cancel',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(Array.isArray(result.linkedOverrides)).toBe(true);
+      expect(Array.isArray(result.conflicts)).toBe(true);
+    });
+
+    it('should not trigger conflict detection for cancel overrides', async () => {
+      const dto: WeeklyOverrideDto = {
+        scheduleId: 1,
+        targetWeek: 'current',
+        overrideType: 'cancel',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+      const querySpy = jest.spyOn(dataSource, 'query').mockResolvedValue([]);
+
+      await service.createWeeklyOverride(dto);
+
+      // For cancel: only schedule→programId lookup may fire; no conflict SQL
+      // Conflict detection SQL query has WHERE start_time < $4 AND end_time > $5 — not called
+      const conflictQueryCalls = querySpy.mock.calls.filter((args) =>
+        String(args[0]).includes('start_time <'),
+      );
+      expect(conflictQueryCalls).toHaveLength(0);
     });
   });
 });

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -43,6 +43,44 @@ export interface WeeklyOverrideDto {
   };
 }
 
+export interface ConflictInfo {
+  channelId: number;
+  channelName: string;
+  programId: number;
+  programName: string;
+  scheduleId?: number;
+  dayOfWeek: string;
+  weekStartDate: string;
+  currentStartTime: string;
+  currentEndTime: string;
+  suggestedAction: 'reschedule' | 'cancel';
+  suggestedStartTime?: string;
+  suggestedEndTime?: string;
+  hasExistingOverride: boolean;
+  existingOverrideId?: string;
+}
+
+export interface ConflictResolutionItem {
+  programId?: number;
+  scheduleId?: number;
+  channelId: number;
+  dayOfWeek: string;
+  weekStartDate: string;
+  action: 'cancel' | 'reschedule' | 'keep';
+  newStartTime?: string;
+  newEndTime?: string;
+}
+
+export interface ResolveConflictsDto {
+  targetWeek: 'current' | 'next';
+  resolutions: ConflictResolutionItem[];
+}
+
+export interface WeeklyOverrideResult extends WeeklyOverride {
+  linkedOverrides: WeeklyOverride[];
+  conflicts: ConflictInfo[];
+}
+
 export interface BulkWeeklyOverrideDto {
   channel_ids: number[];
   targetWeek: 'current' | 'next';
@@ -145,7 +183,7 @@ export class WeeklyOverridesService {
   /**
    * Create a weekly override
    */
-  async createWeeklyOverride(dto: WeeklyOverrideDto): Promise<WeeklyOverride> {
+  async createWeeklyOverride(dto: WeeklyOverrideDto): Promise<WeeklyOverrideResult> {
     // Validate that either scheduleId or programId is provided (but not both)
     if (dto.scheduleId && dto.programId) {
       throw new BadRequestException(
@@ -366,7 +404,82 @@ export class WeeklyOverridesService {
       revalidatePaths: ['/'],
     });
 
-    return override;
+    // Propagate to linked programs and detect conflicts
+    let linkedOverrides: WeeklyOverride[] = [];
+    let conflicts: ConflictInfo[] = [];
+
+    if (dto.overrideType === 'create') {
+      // For create overrides: detect conflicts on the special program's channel
+      const channelId = dto.specialProgram?.channelId;
+      const conflictDay = dto.newDayOfWeek;
+      if (channelId && dto.newStartTime && dto.newEndTime && conflictDay) {
+        const [ch] = await this.dataSource.query(
+          'SELECT name FROM channel WHERE id = $1',
+          [channelId],
+        );
+        conflicts = await this.detectConflictsForChannel(
+          channelId,
+          ch?.name || '',
+          conflictDay,
+          weekStartDate,
+          dto.newStartTime,
+          dto.newEndTime,
+          [], // special programs have no DB program_id to exclude
+        );
+      }
+    } else {
+      let effectiveProgramId: number | undefined;
+      let originalDayOfWeek: string | undefined;
+
+      if (dto.scheduleId) {
+        const [row] = await this.dataSource.query(
+          `SELECT program_id::integer AS program_id, day_of_week FROM schedule WHERE id = $1`,
+          [dto.scheduleId],
+        );
+        if (row) {
+          effectiveProgramId = Number(row.program_id);
+          originalDayOfWeek = row.day_of_week;
+        }
+      } else if (dto.programId) {
+        effectiveProgramId = dto.programId;
+      }
+
+      if (
+        effectiveProgramId &&
+        ['cancel', 'time_change', 'reschedule'].includes(dto.overrideType)
+      ) {
+        linkedOverrides = await this.propagateOverrideToLinkedPrograms(
+          effectiveProgramId,
+          dto.overrideType,
+          weekStartDate,
+          expiresAt,
+          secondsUntilExpiry,
+          dto.newStartTime,
+          dto.newEndTime,
+          dto.newDayOfWeek,
+          originalDayOfWeek,
+        );
+      }
+
+      const conflictDay = dto.newDayOfWeek || originalDayOfWeek;
+      if (
+        effectiveProgramId &&
+        ['time_change', 'reschedule'].includes(dto.overrideType) &&
+        dto.newStartTime &&
+        dto.newEndTime &&
+        conflictDay
+      ) {
+        conflicts = await this.detectConflictsForLinkedChannels(
+          effectiveProgramId,
+          conflictDay,
+          weekStartDate,
+          dto.newStartTime,
+          dto.newEndTime,
+        );
+      }
+    }
+
+    return { ...override, linkedOverrides, conflicts };
   }
 
   /**
@@ -375,7 +488,7 @@ export class WeeklyOverridesService {
   async updateWeeklyOverride(
     overrideId: string,
     dto: Partial<WeeklyOverrideDto>,
-  ): Promise<WeeklyOverride> {
+  ): Promise<WeeklyOverrideResult> {
     // Get the existing override
     const existingOverride = await this.getWeeklyOverride(overrideId);
     if (!existingOverride) {
@@ -550,7 +663,76 @@ export class WeeklyOverridesService {
       revalidatePaths: ['/'],
     });
 
-    return updatedOverride;
+    // Propagate to linked programs and detect conflicts
+    let linkedOverrides: WeeklyOverride[] = [];
+    let conflicts: ConflictInfo[] = [];
+
+    const effectiveType = updatedOverride.overrideType ?? existingOverride.overrideType;
+    if (effectiveType !== 'create') {
+      let effectiveProgramId: number | undefined;
+      let originalDayOfWeek: string | undefined;
+
+      const effectiveScheduleId =
+        updatedOverride.scheduleId ?? existingOverride.scheduleId;
+      const effectiveProgramIdField =
+        updatedOverride.programId ?? existingOverride.programId;
+
+      if (effectiveScheduleId) {
+        const [row] = await this.dataSource.query(
+          `SELECT program_id::integer AS program_id, day_of_week FROM schedule WHERE id = $1`,
+          [effectiveScheduleId],
+        );
+        if (row) {
+          effectiveProgramId = Number(row.program_id);
+          originalDayOfWeek = row.day_of_week;
+        }
+      } else if (effectiveProgramIdField) {
+        effectiveProgramId = effectiveProgramIdField;
+      }
+
+      if (
+        effectiveProgramId &&
+        ['cancel', 'time_change', 'reschedule'].includes(effectiveType)
+      ) {
+        linkedOverrides = await this.propagateOverrideToLinkedPrograms(
+          effectiveProgramId,
+          effectiveType,
+          existingOverride.weekStartDate,
+          existingOverride.expiresAt,
+          60 * 60 * 24 * 7,
+          updatedOverride.newStartTime ?? existingOverride.newStartTime,
+          updatedOverride.newEndTime ?? existingOverride.newEndTime,
+          updatedOverride.newDayOfWeek ?? existingOverride.newDayOfWeek,
+          originalDayOfWeek,
+        );
+      }
+
+      const conflictStart =
+        updatedOverride.newStartTime ?? existingOverride.newStartTime;
+      const conflictEnd =
+        updatedOverride.newEndTime ?? existingOverride.newEndTime;
+      const conflictDay =
+        updatedOverride.newDayOfWeek ??
+        existingOverride.newDayOfWeek ??
+        originalDayOfWeek;
+      if (
+        effectiveProgramId &&
+        ['time_change', 'reschedule'].includes(effectiveType) &&
+        conflictStart &&
+        conflictEnd &&
+        conflictDay
+      ) {
+        conflicts = await this.detectConflictsForLinkedChannels(
+          effectiveProgramId,
+          conflictDay,
+          existingOverride.weekStartDate,
+          conflictStart,
+          conflictEnd,
+        );
+      }
+    }
+
+    return { ...updatedOverride, linkedOverrides, conflicts };
   }
 
   /**
@@ -1221,7 +1403,7 @@ export class WeeklyOverridesService {
   /**
    * Create a special-program override for multiple channels at once
    */
-  async createBulk(dto: BulkWeeklyOverrideDto): Promise<WeeklyOverride[]> {
+  async createBulk(dto: BulkWeeklyOverrideDto): Promise<{ overrides: WeeklyOverride[]; conflicts: ConflictInfo[] }> {
     if (dto.overrideType !== 'create') {
       throw new BadRequestException(
         'Bulk override creation only supports overrideType "create"',
@@ -1352,7 +1534,27 @@ export class WeeklyOverridesService {
       revalidatePaths: ['/'],
     });
 
-    return created;
+    // Detect conflicts for each created override's channel
+    const conflicts: ConflictInfo[] = [];
+    if (dto.newStartTime && dto.newEndTime && dto.newDayOfWeek) {
+      for (const override of created) {
+        const channelId = override.specialProgram?.channelId;
+        if (!channelId) continue;
+        const channel = channelMap.get(channelId);
+        const channelConflicts = await this.detectConflictsForChannel(
+          channelId,
+          channel?.name || '',
+          dto.newDayOfWeek.toLowerCase(),
+          weekStartDate,
+          dto.newStartTime,
+          dto.newEndTime,
+          [],
+        );
+        conflicts.push(...channelConflicts);
+      }
+    }
+
+    return { overrides: created, conflicts };
   }
 
   /**
@@ -1414,5 +1616,335 @@ export class WeeklyOverridesService {
     });
 
     return keysToDelete.length;
+  }
+
+  // ─── Conflict detection & linked-program propagation ──────────────────────
+
+  private buildSmartSuggestion(
+    confStart: string,
+    confEnd: string,
+    golStart: string,
+    golEnd: string,
+  ): {
+    action: 'reschedule' | 'cancel';
+    suggestedStart?: string;
+    suggestedEnd?: string;
+  } {
+    const startsBeforeGol = confStart < golStart;
+    const endsAfterGol = confEnd > golEnd;
+
+    if (startsBeforeGol && !endsAfterGol) {
+      return { action: 'reschedule', suggestedStart: confStart, suggestedEnd: golStart };
+    }
+    if (!startsBeforeGol && endsAfterGol) {
+      return { action: 'reschedule', suggestedStart: golEnd, suggestedEnd: confEnd };
+    }
+    return { action: 'cancel' };
+  }
+
+  private async detectConflictsForChannel(
+    channelId: number,
+    channelName: string,
+    dayOfWeek: string,
+    weekStartDate: string,
+    newStartTime: string,
+    newEndTime: string,
+    excludeProgramIds: number[],
+  ): Promise<ConflictInfo[]> {
+    const rows = await this.dataSource.query(
+      `SELECT s.id AS schedule_id, s.day_of_week, s.start_time, s.end_time,
+              p.id AS program_id, p.name AS program_name
+       FROM schedule s
+       JOIN program p ON p.id = s.program_id::integer
+       WHERE p.channel_id = $1
+         AND p.id != ALL($2::integer[])
+         AND p.is_visible = true
+         AND s.day_of_week = $3
+         AND s.schedule_type = 'weekly'
+         AND s.start_time < $4
+         AND s.end_time > $5`,
+      [channelId, excludeProgramIds, dayOfWeek, newEndTime, newStartTime],
+    );
+
+    if (rows.length === 0) return [];
+
+    const weekOverrides = await this.getOverridesForWeek(weekStartDate);
+    const conflicts: ConflictInfo[] = [];
+
+    for (const row of rows) {
+      const programId = Number(row.program_id);
+      const scheduleId = Number(row.schedule_id);
+
+      const existingOverride = weekOverrides.find(
+        (o) => o.programId === programId || o.scheduleId === scheduleId,
+      );
+
+      if (existingOverride?.overrideType === 'cancel') continue;
+
+      let effectiveStart: string = row.start_time;
+      let effectiveEnd: string = row.end_time;
+      if (existingOverride?.newStartTime) effectiveStart = existingOverride.newStartTime;
+      if (existingOverride?.newEndTime) effectiveEnd = existingOverride.newEndTime;
+
+      if (effectiveStart >= newEndTime || effectiveEnd <= newStartTime) continue;
+
+      const { action, suggestedStart, suggestedEnd } = this.buildSmartSuggestion(
+        effectiveStart,
+        effectiveEnd,
+        newStartTime,
+        newEndTime,
+      );
+
+      conflicts.push({
+        channelId,
+        channelName,
+        programId,
+        programName: row.program_name,
+        scheduleId,
+        dayOfWeek,
+        weekStartDate,
+        currentStartTime: effectiveStart,
+        currentEndTime: effectiveEnd,
+        suggestedAction: action,
+        suggestedStartTime: suggestedStart,
+        suggestedEndTime: suggestedEnd,
+        hasExistingOverride: !!existingOverride,
+        existingOverrideId: existingOverride?.id,
+      });
+    }
+
+    return conflicts;
+  }
+
+  private async detectConflictsForLinkedChannels(
+    programId: number,
+    dayOfWeek: string,
+    weekStartDate: string,
+    newStartTime: string,
+    newEndTime: string,
+  ): Promise<ConflictInfo[]> {
+    const rows = await this.dataSource.query(
+      `SELECT p.id, p.link_group_id, p.channel_id, c.name AS channel_name
+       FROM program p
+       JOIN channel c ON c.id = p.channel_id
+       WHERE p.id = $1`,
+      [programId],
+    );
+    if (!rows.length) return [];
+
+    const programInfo = rows[0];
+    const allPrograms: Array<{ id: number; channel_id: number; channel_name: string }> = [
+      {
+        id: Number(programInfo.id),
+        channel_id: Number(programInfo.channel_id),
+        channel_name: programInfo.channel_name,
+      },
+    ];
+
+    if (programInfo.link_group_id) {
+      const linked = await this.dataSource.query(
+        `SELECT p.id, p.channel_id, c.name AS channel_name
+         FROM program p
+         JOIN channel c ON c.id = p.channel_id
+         WHERE p.link_group_id = $1 AND p.id != $2`,
+        [programInfo.link_group_id, programId],
+      );
+      allPrograms.push(
+        ...linked.map((l: any) => ({
+          id: Number(l.id),
+          channel_id: Number(l.channel_id),
+          channel_name: l.channel_name,
+        })),
+      );
+    }
+
+    const excludeProgramIds = allPrograms.map((p) => p.id);
+    const conflicts: ConflictInfo[] = [];
+
+    for (const p of allPrograms) {
+      const channelConflicts = await this.detectConflictsForChannel(
+        p.channel_id,
+        p.channel_name,
+        dayOfWeek,
+        weekStartDate,
+        newStartTime,
+        newEndTime,
+        excludeProgramIds,
+      );
+      conflicts.push(...channelConflicts);
+    }
+
+    return conflicts;
+  }
+
+  private async propagateOverrideToLinkedPrograms(
+    programId: number,
+    overrideType: string,
+    weekStartDate: string,
+    expiresAt: string,
+    secondsUntilExpiry: number,
+    newStartTime?: string,
+    newEndTime?: string,
+    newDayOfWeek?: string,
+    originalDayOfWeek?: string,
+  ): Promise<WeeklyOverride[]> {
+    const [programInfo] = await this.dataSource.query(
+      `SELECT link_group_id FROM program WHERE id = $1`,
+      [programId],
+    );
+    if (!programInfo?.link_group_id) return [];
+
+    const linkedPrograms = await this.dataSource.query(
+      `SELECT id FROM program WHERE link_group_id = $1 AND id != $2`,
+      [programInfo.link_group_id, programId],
+    );
+    if (!linkedPrograms.length) return [];
+
+    const created: WeeklyOverride[] = [];
+    const dayToFind = originalDayOfWeek;
+
+    for (const linked of linkedPrograms) {
+      const linkedId = Number(linked.id);
+      let overrideId: string;
+      let linkedScheduleId: number | undefined;
+
+      if (dayToFind) {
+        const [linkedSchedule] = await this.dataSource.query(
+          `SELECT id FROM schedule WHERE program_id = $1 AND day_of_week = $2 AND schedule_type = 'weekly'`,
+          [linkedId.toString(), dayToFind],
+        );
+        if (linkedSchedule) {
+          linkedScheduleId = Number(linkedSchedule.id);
+          overrideId = `${linkedScheduleId}_${weekStartDate}`;
+        } else {
+          overrideId = `program_${linkedId}_${weekStartDate}`;
+        }
+      } else {
+        overrideId = `program_${linkedId}_${weekStartDate}`;
+      }
+
+      const existing = await this.getWeeklyOverride(overrideId);
+      if (existing) {
+        this.logger.warn(
+          `[LINKED-OVERRIDE] Override ${overrideId} already exists, updating`,
+        );
+        // Update the existing override with the new values
+        const updatedLinked: WeeklyOverride = {
+          ...existing,
+          overrideType: overrideType as any,
+          newStartTime,
+          newEndTime,
+          newDayOfWeek: newDayOfWeek?.toLowerCase(),
+        };
+        await this.redisService.set(
+          `weekly_override:${overrideId}`,
+          updatedLinked,
+          secondsUntilExpiry,
+        );
+        created.push(updatedLinked);
+        continue;
+      }
+
+      const linkedOverride: WeeklyOverride = {
+        id: overrideId,
+        ...(linkedScheduleId ? { scheduleId: linkedScheduleId } : { programId: linkedId }),
+        weekStartDate,
+        overrideType: overrideType as any,
+        newStartTime,
+        newEndTime,
+        newDayOfWeek: newDayOfWeek?.toLowerCase(),
+        expiresAt,
+        createdAt: new Date(),
+        panelists: [],
+      };
+
+      await this.redisService.set(
+        `weekly_override:${overrideId}`,
+        linkedOverride,
+        secondsUntilExpiry,
+      );
+
+      created.push(linkedOverride);
+      this.logger.log(
+        `[LINKED-OVERRIDE] Propagated override ${overrideId} for linked program ${linkedId}`,
+      );
+    }
+
+    return created;
+  }
+
+  async resolveConflicts(dto: ResolveConflictsDto): Promise<{ resolved: number; skipped: number }> {
+    const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
+    let targetWeekStart: dayjs.Dayjs;
+
+    if (dto.targetWeek === 'current') {
+      targetWeekStart = now.startOf('week');
+    } else {
+      targetWeekStart = now.add(1, 'week').startOf('week');
+    }
+
+    const weekStartDate = targetWeekStart.format('YYYY-MM-DD');
+    const expiresAt = targetWeekStart.add(1, 'week').format('YYYY-MM-DD HH:mm:ss');
+    const secondsUntilExpiry = this.dayjs(expiresAt)
+      .tz('America/Argentina/Buenos_Aires')
+      .diff(now, 'seconds');
+
+    let resolved = 0;
+    let skipped = 0;
+
+    for (const resolution of dto.resolutions) {
+      if (resolution.action === 'keep') {
+        skipped++;
+        continue;
+      }
+
+      let overrideId: string;
+      if (resolution.scheduleId) {
+        overrideId = `${resolution.scheduleId}_${weekStartDate}`;
+      } else if (resolution.programId) {
+        overrideId = `program_${resolution.programId}_${weekStartDate}`;
+      } else {
+        skipped++;
+        continue;
+      }
+
+      const overrideType = resolution.action === 'cancel' ? 'cancel' : 'time_change';
+
+      const override: WeeklyOverride = {
+        id: overrideId,
+        ...(resolution.scheduleId
+          ? { scheduleId: resolution.scheduleId }
+          : { programId: resolution.programId }),
+        weekStartDate,
+        overrideType: overrideType as any,
+        newStartTime: resolution.newStartTime,
+        newEndTime: resolution.newEndTime,
+        expiresAt,
+        createdAt: new Date(),
+        panelists: [],
+      };
+
+      await this.redisService.set(
+        `weekly_override:${overrideId}`,
+        override,
+        secondsUntilExpiry,
+      );
+
+      resolved++;
+    }
+
+    await this.redisService.del('schedules:week:complete');
+    await this.updateWeeklyCacheForWeek(weekStartDate);
+    this.schedulesService?.debouncedWarmSchedulesCache?.();
+
+    await this.notifyUtil.notifyAndRevalidate({
+      eventType: 'conflicts_resolved',
+      entity: 'override',
+      entityId: 'bulk',
+      payload: { resolved, skipped },
+      revalidatePaths: ['/'],
+    });
+
+    return { resolved, skipped };
   }
 }

--- a/src/users/subscription.service.spec.ts
+++ b/src/users/subscription.service.spec.ts
@@ -61,6 +61,7 @@ describe('SubscriptionService', () => {
     schedules: [],
     style_override: null,
     is_premiere: false,
+    link_group_id: null,
   };
 
   const mockSubscription: UserSubscription = {


### PR DESCRIPTION
## [1.33.0] - 2026-06-23

### Added

- **Programas linkeados (`link_group_id`)**: nueva columna UUID en la entidad `program` que agrupa programas que se transmiten simultáneamente en distintos canales. Migración `AddLinkGroupIdToPrograms` incluida.
- **Propagación de overrides a programas linkeados**: al crear o actualizar un `weekly-override` (tipos `cancel`, `time_change`, `reschedule`) sobre un programa con `link_group_id`, el backend replica automáticamente el override a todos los programas del mismo grupo.
- **Detección automática de conflictos de grilla**: tras aplicar un override, se detectan los programas con horario superpuesto en los canales afectados y se devuelven como array `conflicts` en la respuesta de `POST /weekly-overrides` y `POST /weekly-overrides/bulk`.
- **`POST /weekly-overrides/resolve-conflicts`**: nuevo endpoint para aplicar resoluciones (`cancel`, `time_change`, `keep`) sobre los conflictos detectados.

### Fixed

- La detección de conflictos ahora se activa correctamente para overrides de tipo `create` y para el endpoint `POST /weekly-overrides/bulk`.
- Los programas con `is_visible = false` ya no se incluyen en la lista de conflictos detectados.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)