### PR TITLE
Release 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Detección de conflictos en programas que cruzan medianoche**: la detección de horarios superpuestos comparaba `start_time`/`end_time` como strings, lo que fallaba cuando un programa especial cruza las 00:00 (ej. 23:00–00:30), ya que ese bloque se guarda con `end_time < start_time` bajo el mismo `day_of_week`. Ahora la comparación normaliza ambos horarios a minutos con wraparound antes de evaluar el solapamiento, igual que el resto del código (`timezone.util.ts`). También corrige `buildSmartSuggestion`, que tenía el mismo problema al sugerir un horario de reprogramación.
+- **`POST /schedules/bulk` rechazaba todas las requests con 400**: `CreateBulkSchedulesDto.skipLinkPropagation` no tenía decoradores de `class-validator`. Con el `ValidationPipe` global (`whitelist` + `forbidNonWhitelisted`) y el target `ES2023` de TypeScript (semántica de class-fields tipo `define`), toda instancia del DTO incluía esa propiedad como `undefined` aunque no viniera en el body, y `class-validator` la rechazaba como propiedad desconocida. Esto rompía la creación de horarios en bulk para cualquier programa existente.
+
 ## [1.33.0] - 2026-06-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
-## [Unreleased]
+## [1.34.0] - 2026-06-24
 
 ### Fixed
 

--- a/src/schedules/dto/create-schedule.dto.spec.ts
+++ b/src/schedules/dto/create-schedule.dto.spec.ts
@@ -1,4 +1,5 @@
 import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
 import {
   CreateScheduleDto,
   CreateScheduleItemDto,
@@ -141,5 +142,45 @@ describe('CreateBulkSchedulesDto', () => {
     // Without reflection metadata, nested validation won't work, so we expect no errors
     // The test is adjusted to reflect the actual behavior
     expect(errors.length).toBe(0);
+  });
+
+  // Mirrors the global ValidationPipe config in main.ts (whitelist +
+  // forbidNonWhitelisted, with plainToInstance instead of manual property
+  // assignment). This is what actually runs in production for HTTP
+  // requests, and is the only way to catch undecorated class fields
+  // getting rejected as "unknown" properties.
+  it('debería aceptar un payload real de un caller externo (sin skipLinkPropagation) bajo el ValidationPipe global', async () => {
+    const instance = plainToInstance(CreateBulkSchedulesDto, {
+      programId: '1',
+      channelId: '1',
+      schedules: [
+        { dayOfWeek: 'monday', startTime: '10:00', endTime: '12:00' },
+      ],
+    });
+
+    const errors = await validate(instance, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it('debería aceptar skipLinkPropagation bajo el ValidationPipe global', async () => {
+    const instance = plainToInstance(CreateBulkSchedulesDto, {
+      programId: '1',
+      channelId: '1',
+      schedules: [
+        { dayOfWeek: 'monday', startTime: '10:00', endTime: '12:00' },
+      ],
+      skipLinkPropagation: true,
+    });
+
+    const errors = await validate(instance, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    expect(errors).toEqual([]);
   });
 });

--- a/src/schedules/dto/create-schedule.dto.ts
+++ b/src/schedules/dto/create-schedule.dto.ts
@@ -10,6 +10,7 @@ import {
   Min,
   Max,
   IsDateString,
+  IsBoolean,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -92,5 +93,7 @@ export class CreateBulkSchedulesDto {
   @Type(() => CreateScheduleItemDto)
   schedules: CreateScheduleItemDto[];
 
+  @IsOptional()
+  @IsBoolean()
   skipLinkPropagation?: boolean;
 }

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -141,18 +141,23 @@ describe('WeeklyOverridesService', () => {
       jest.spyOn(redisService, 'get').mockResolvedValue(null); // No existing override
       jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
       jest.spyOn(redisService, 'del').mockResolvedValue(undefined);
-      jest.spyOn(dataSource, 'query').mockResolvedValue([
-        {
-          id: 1,
-          name: 'Test Channel',
-          handle: 'test',
-          youtube_channel_id: 'test123',
-          logo_url: null,
-          description: null,
-          order: 1,
-          is_visible: true,
-        },
-      ]);
+      jest.spyOn(dataSource, 'query').mockImplementation((sql: string) => {
+        if (sql.includes('FROM channel')) {
+          return Promise.resolve([
+            {
+              id: 1,
+              name: 'Test Channel',
+              handle: 'test',
+              youtube_channel_id: 'test123',
+              logo_url: null,
+              description: null,
+              order: 1,
+              is_visible: true,
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      });
 
       const result = await service.createWeeklyOverride(dto);
 
@@ -1026,7 +1031,12 @@ describe('WeeklyOverridesService', () => {
         .mockResolvedValueOnce([{ link_group_id: null }])
         // detectConflictsForLinkedChannels: program info
         .mockResolvedValueOnce([
-          { id: 1, link_group_id: null, channel_id: 1, channel_name: 'Canal 1' },
+          {
+            id: 1,
+            link_group_id: null,
+            channel_id: 1,
+            channel_name: 'Canal 1',
+          },
         ])
         // detectConflictsForChannel SQL: no overlapping rows
         .mockResolvedValueOnce([]);
@@ -1060,7 +1070,12 @@ describe('WeeklyOverridesService', () => {
         .mockResolvedValueOnce([{ link_group_id: null }])
         // detectConflictsForLinkedChannels: program info
         .mockResolvedValueOnce([
-          { id: 1, link_group_id: null, channel_id: 1, channel_name: 'Canal Test' },
+          {
+            id: 1,
+            link_group_id: null,
+            channel_id: 1,
+            channel_name: 'Canal Test',
+          },
         ])
         // detectConflictsForChannel: overlapping schedule rows
         .mockResolvedValueOnce([
@@ -1098,6 +1113,102 @@ describe('WeeklyOverridesService', () => {
       expect(result.conflicts[0].channelName).toBe('Canal Test');
       expect(result.conflicts[0].dayOfWeek).toBe('monday');
     });
+
+    it('should detect conflicts for schedules that cross midnight', async () => {
+      // "El que ríe último" airs 23:00 → 00:30 (next day), same as the
+      // newly created special program. Both start_time/end_time are stored
+      // anchored to the same day_of_week with end_time < start_time.
+      jest
+        .spyOn(dataSource, 'query')
+        .mockResolvedValueOnce([{ program_id: 1, day_of_week: 'monday' }])
+        .mockResolvedValueOnce([{ link_group_id: null }])
+        .mockResolvedValueOnce([
+          {
+            id: 1,
+            link_group_id: null,
+            channel_id: 1,
+            channel_name: 'Canal Test',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            schedule_id: 99,
+            day_of_week: 'monday',
+            start_time: '23:00:00',
+            end_time: '00:30:00',
+            program_id: 42,
+            program_name: 'El que ríe último',
+          },
+        ])
+        .mockResolvedValue([]);
+
+      const dto: WeeklyOverrideDto = {
+        scheduleId: 1,
+        targetWeek: 'current',
+        overrideType: 'time_change',
+        newStartTime: '23:00',
+        newEndTime: '00:30',
+        newDayOfWeek: 'monday',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.conflicts).toHaveLength(1);
+      expect(result.conflicts[0].programName).toBe('El que ríe último');
+    });
+
+    it('should not flag adjacent (non-overlapping) cross-midnight schedules as conflicts', async () => {
+      // New program ends exactly when the existing one starts: 22:00→23:00
+      // vs. 23:00→00:30. No actual overlap.
+      jest
+        .spyOn(dataSource, 'query')
+        .mockResolvedValueOnce([{ program_id: 1, day_of_week: 'monday' }])
+        .mockResolvedValueOnce([{ link_group_id: null }])
+        .mockResolvedValueOnce([
+          {
+            id: 1,
+            link_group_id: null,
+            channel_id: 1,
+            channel_name: 'Canal Test',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            schedule_id: 99,
+            day_of_week: 'monday',
+            start_time: '23:00:00',
+            end_time: '00:30:00',
+            program_id: 42,
+            program_name: 'El que ríe último',
+          },
+        ])
+        .mockResolvedValue([]);
+
+      const dto: WeeklyOverrideDto = {
+        scheduleId: 1,
+        targetWeek: 'current',
+        overrideType: 'time_change',
+        newStartTime: '22:00',
+        newEndTime: '23:00',
+        newDayOfWeek: 'monday',
+      };
+
+      jest
+        .spyOn(schedulesRepo, 'findOne')
+        .mockResolvedValue(mockSchedule as any);
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.conflicts).toEqual([]);
+    });
   });
 
   describe('resolveConflicts', () => {
@@ -1121,7 +1232,9 @@ describe('WeeklyOverridesService', () => {
       expect(result.skipped).toBe(1);
       expect(result.resolved).toBe(0);
       // No override written (only the live_notification key is set for the summary event)
-      const overrideSetCalls = (redisService.set as jest.Mock).mock.calls.filter(
+      const overrideSetCalls = (
+        redisService.set as jest.Mock
+      ).mock.calls.filter(
         (args) => !String(args[0]).startsWith('live_notification:'),
       );
       expect(overrideSetCalls).toHaveLength(0);

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -183,7 +183,9 @@ export class WeeklyOverridesService {
   /**
    * Create a weekly override
    */
-  async createWeeklyOverride(dto: WeeklyOverrideDto): Promise<WeeklyOverrideResult> {
+  async createWeeklyOverride(
+    dto: WeeklyOverrideDto,
+  ): Promise<WeeklyOverrideResult> {
     // Validate that either scheduleId or programId is provided (but not both)
     if (dto.scheduleId && dto.programId) {
       throw new BadRequestException(
@@ -667,7 +669,8 @@ export class WeeklyOverridesService {
     let linkedOverrides: WeeklyOverride[] = [];
     let conflicts: ConflictInfo[] = [];
 
-    const effectiveType = updatedOverride.overrideType ?? existingOverride.overrideType;
+    const effectiveType =
+      updatedOverride.overrideType ?? existingOverride.overrideType;
     if (effectiveType !== 'create') {
       let effectiveProgramId: number | undefined;
       let originalDayOfWeek: string | undefined;
@@ -1403,7 +1406,9 @@ export class WeeklyOverridesService {
   /**
    * Create a special-program override for multiple channels at once
    */
-  async createBulk(dto: BulkWeeklyOverrideDto): Promise<{ overrides: WeeklyOverride[]; conflicts: ConflictInfo[] }> {
+  async createBulk(
+    dto: BulkWeeklyOverrideDto,
+  ): Promise<{ overrides: WeeklyOverride[]; conflicts: ConflictInfo[] }> {
     if (dto.overrideType !== 'create') {
       throw new BadRequestException(
         'Bulk override creation only supports overrideType "create"',
@@ -1435,7 +1440,9 @@ export class WeeklyOverridesService {
     }
 
     const weekStartDate = targetWeekStart.format('YYYY-MM-DD');
-    const expiresAt = targetWeekStart.add(1, 'week').format('YYYY-MM-DD HH:mm:ss');
+    const expiresAt = targetWeekStart
+      .add(1, 'week')
+      .format('YYYY-MM-DD HH:mm:ss');
     const secondsUntilExpiry = this.dayjs(expiresAt)
       .tz('America/Argentina/Buenos_Aires')
       .diff(now, 'seconds');
@@ -1448,7 +1455,9 @@ export class WeeklyOverridesService {
       });
       if (panelists.length !== dto.panelistIds.length) {
         const foundIds = panelists.map((p) => p.id);
-        const missingIds = dto.panelistIds.filter((id) => !foundIds.includes(id));
+        const missingIds = dto.panelistIds.filter(
+          (id) => !foundIds.includes(id),
+        );
         throw new NotFoundException(
           `Panelists with IDs ${missingIds.join(', ')} not found`,
         );
@@ -1467,7 +1476,9 @@ export class WeeklyOverridesService {
       channelRows.map((c: any) => [c.id, c]),
     );
 
-    const missingChannelIds = dto.channel_ids.filter((id) => !channelMap.has(id));
+    const missingChannelIds = dto.channel_ids.filter(
+      (id) => !channelMap.has(id),
+    );
     if (missingChannelIds.length > 0) {
       throw new NotFoundException(
         `Channels not found: ${missingChannelIds.join(', ')}`,
@@ -1620,6 +1631,35 @@ export class WeeklyOverridesService {
 
   // ─── Conflict detection & linked-program propagation ──────────────────────
 
+  /** Minutes since midnight for an 'HH:MM' / 'HH:MM:SS' time string. */
+  private toMinutes(time: string): number {
+    const [h, m] = time.split(':').map(Number);
+    return h * 60 + m;
+  }
+
+  /**
+   * Converts a start/end pair anchored to the same day_of_week into a
+   * minutes range on a 48h timeline. If end <= start, the block crosses
+   * midnight and end is pushed into the next day (+1440) so overlap math
+   * works the same way as same-day blocks.
+   */
+  private toOverlapRange(
+    start: string,
+    end: string,
+  ): { start: number; end: number } {
+    const startMin = this.toMinutes(start);
+    let endMin = this.toMinutes(end);
+    if (endMin <= startMin) endMin += 24 * 60;
+    return { start: startMin, end: endMin };
+  }
+
+  private rangesOverlap(
+    a: { start: number; end: number },
+    b: { start: number; end: number },
+  ): boolean {
+    return a.start < b.end && b.start < a.end;
+  }
+
   private buildSmartSuggestion(
     confStart: string,
     confEnd: string,
@@ -1630,14 +1670,24 @@ export class WeeklyOverridesService {
     suggestedStart?: string;
     suggestedEnd?: string;
   } {
-    const startsBeforeGol = confStart < golStart;
-    const endsAfterGol = confEnd > golEnd;
+    const conf = this.toOverlapRange(confStart, confEnd);
+    const gol = this.toOverlapRange(golStart, golEnd);
+    const startsBeforeGol = conf.start < gol.start;
+    const endsAfterGol = conf.end > gol.end;
 
     if (startsBeforeGol && !endsAfterGol) {
-      return { action: 'reschedule', suggestedStart: confStart, suggestedEnd: golStart };
+      return {
+        action: 'reschedule',
+        suggestedStart: confStart,
+        suggestedEnd: golStart,
+      };
     }
     if (!startsBeforeGol && endsAfterGol) {
-      return { action: 'reschedule', suggestedStart: golEnd, suggestedEnd: confEnd };
+      return {
+        action: 'reschedule',
+        suggestedStart: golEnd,
+        suggestedEnd: confEnd,
+      };
     }
     return { action: 'cancel' };
   }
@@ -1660,16 +1710,15 @@ export class WeeklyOverridesService {
          AND p.id != ALL($2::integer[])
          AND p.is_visible = true
          AND s.day_of_week = $3
-         AND s.schedule_type = 'weekly'
-         AND s.start_time < $4
-         AND s.end_time > $5`,
-      [channelId, excludeProgramIds, dayOfWeek, newEndTime, newStartTime],
+         AND s.schedule_type = 'weekly'`,
+      [channelId, excludeProgramIds, dayOfWeek],
     );
 
     if (rows.length === 0) return [];
 
     const weekOverrides = await this.getOverridesForWeek(weekStartDate);
     const conflicts: ConflictInfo[] = [];
+    const newRange = this.toOverlapRange(newStartTime, newEndTime);
 
     for (const row of rows) {
       const programId = Number(row.program_id);
@@ -1683,17 +1732,21 @@ export class WeeklyOverridesService {
 
       let effectiveStart: string = row.start_time;
       let effectiveEnd: string = row.end_time;
-      if (existingOverride?.newStartTime) effectiveStart = existingOverride.newStartTime;
-      if (existingOverride?.newEndTime) effectiveEnd = existingOverride.newEndTime;
+      if (existingOverride?.newStartTime)
+        effectiveStart = existingOverride.newStartTime;
+      if (existingOverride?.newEndTime)
+        effectiveEnd = existingOverride.newEndTime;
 
-      if (effectiveStart >= newEndTime || effectiveEnd <= newStartTime) continue;
+      const existingRange = this.toOverlapRange(effectiveStart, effectiveEnd);
+      if (!this.rangesOverlap(newRange, existingRange)) continue;
 
-      const { action, suggestedStart, suggestedEnd } = this.buildSmartSuggestion(
-        effectiveStart,
-        effectiveEnd,
-        newStartTime,
-        newEndTime,
-      );
+      const { action, suggestedStart, suggestedEnd } =
+        this.buildSmartSuggestion(
+          effectiveStart,
+          effectiveEnd,
+          newStartTime,
+          newEndTime,
+        );
 
       conflicts.push({
         channelId,
@@ -1733,7 +1786,11 @@ export class WeeklyOverridesService {
     if (!rows.length) return [];
 
     const programInfo = rows[0];
-    const allPrograms: Array<{ id: number; channel_id: number; channel_name: string }> = [
+    const allPrograms: Array<{
+      id: number;
+      channel_id: number;
+      channel_name: string;
+    }> = [
       {
         id: Number(programInfo.id),
         channel_id: Number(programInfo.channel_id),
@@ -1847,7 +1904,9 @@ export class WeeklyOverridesService {
 
       const linkedOverride: WeeklyOverride = {
         id: overrideId,
-        ...(linkedScheduleId ? { scheduleId: linkedScheduleId } : { programId: linkedId }),
+        ...(linkedScheduleId
+          ? { scheduleId: linkedScheduleId }
+          : { programId: linkedId }),
         weekStartDate,
         overrideType: overrideType as any,
         newStartTime,
@@ -1873,7 +1932,9 @@ export class WeeklyOverridesService {
     return created;
   }
 
-  async resolveConflicts(dto: ResolveConflictsDto): Promise<{ resolved: number; skipped: number }> {
+  async resolveConflicts(
+    dto: ResolveConflictsDto,
+  ): Promise<{ resolved: number; skipped: number }> {
     const now = this.dayjs().tz('America/Argentina/Buenos_Aires');
     let targetWeekStart: dayjs.Dayjs;
 
@@ -1884,7 +1945,9 @@ export class WeeklyOverridesService {
     }
 
     const weekStartDate = targetWeekStart.format('YYYY-MM-DD');
-    const expiresAt = targetWeekStart.add(1, 'week').format('YYYY-MM-DD HH:mm:ss');
+    const expiresAt = targetWeekStart
+      .add(1, 'week')
+      .format('YYYY-MM-DD HH:mm:ss');
     const secondsUntilExpiry = this.dayjs(expiresAt)
       .tz('America/Argentina/Buenos_Aires')
       .diff(now, 'seconds');
@@ -1908,7 +1971,8 @@ export class WeeklyOverridesService {
         continue;
       }
 
-      const overrideType = resolution.action === 'cancel' ? 'cancel' : 'time_change';
+      const overrideType =
+        resolution.action === 'cancel' ? 'cancel' : 'time_change';
 
       const override: WeeklyOverride = {
         id: overrideId,


### PR DESCRIPTION
## [1.34.0] - 2026-06-24

### Fixed

- **Detección de conflictos en programas que cruzan medianoche**: la detección de horarios superpuestos comparaba `start_time`/`end_time` como strings, lo que fallaba cuando un programa especial cruza las 00:00 (ej. 23:00–00:30), ya que ese bloque se guarda con `end_time < start_time` bajo el mismo `day_of_week`. Ahora la comparación normaliza ambos horarios a minutos con wraparound antes de evaluar el solapamiento, igual que el resto del código (`timezone.util.ts`). También corrige `buildSmartSuggestion`, que tenía el mismo problema al sugerir un horario de reprogramación.
- **`POST /schedules/bulk` rechazaba todas las requests con 400**: `CreateBulkSchedulesDto.skipLinkPropagation` no tenía decoradores de `class-validator`. Con el `ValidationPipe` global (`whitelist` + `forbidNonWhitelisted`) y el target `ES2023` de TypeScript (semántica de class-fields tipo `define`), toda instancia del DTO incluía esa propiedad como `undefined` aunque no viniera en el body, y `class-validator` la rechazaba como propiedad desconocida. Esto rompía la creación de horarios en bulk para cualquier programa existente.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)