### PR TITLE
Fix: skip push notifications for programs with is_visible = false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Notificaciones de suscripciones sobre programas ocultos**: el cron de notificaciones enviaba alertas de "en 10 minutos comienza X" para programas con `is_visible = false`. El filtro de `dueSchedules` ahora excluye explícitamente los programas con `is_visible !== true`, evitando notificaciones sobre programas que ya no están activos en la grilla.
+
 ## [1.34.0] - 2026-06-24
 
 ### Fixed

--- a/src/push/push.scheduler.spec.ts
+++ b/src/push/push.scheduler.spec.ts
@@ -63,6 +63,7 @@ describe('PushScheduler', () => {
     name: 'Test Program',
     description: 'Test program description',
     logo_url: 'https://example.com/program-logo.png',
+    is_visible: true,
     channel: mockChannel,
   };
 
@@ -490,6 +491,24 @@ describe('PushScheduler', () => {
 
       await scheduler.handleNotificationsCron();
 
+      expect(mockPushService.sendNotification).not.toHaveBeenCalled();
+    });
+
+    it('should not send notifications for programs with is_visible = false', async () => {
+      const hiddenProgram = { ...mockProgram, is_visible: false };
+      const hiddenSchedule = { ...mockSchedule, program: hiddenProgram };
+
+      const schedulesService = module.get(SchedulesService);
+      jest
+        .spyOn(schedulesService, 'findAll')
+        .mockResolvedValue([hiddenSchedule]);
+
+      await scheduler.handleNotificationsCron();
+
+      expect(scheduler['logger'].debug).toHaveBeenCalledWith(
+        'Ningún programa coincide.',
+      );
+      expect(mockUserSubscriptionRepository.find).not.toHaveBeenCalled();
       expect(mockPushService.sendNotification).not.toHaveBeenCalled();
     });
 

--- a/src/push/push.scheduler.ts
+++ b/src/push/push.scheduler.ts
@@ -54,9 +54,9 @@ export class PushScheduler {
       skipCache: false, // ✅ IMPORTANTE: Usar cache para reducir carga en DB
     });
 
-    // Filtrar schedules que empiezan en 10 min
+    // Filtrar schedules que empiezan en 10 min, excluyendo programas ocultos
     const dueSchedules = allSchedules.filter(
-      (s) => s.start_time === timeString,
+      (s) => s.start_time === timeString && s.program?.is_visible === true,
     );
     if (dueSchedules.length === 0) {
       this.logger.debug('Ningún programa coincide.');


### PR DESCRIPTION
## Summary

- El cron de notificaciones (`handleNotificationsCron`) enviaba alertas de "en 10 minutos comienza X" para programas marcados con `is_visible = false`
- El filtro de `dueSchedules` ahora requiere `program.is_visible === true`, descartando programas ocultos antes de consultar suscripciones o enviar pushes
- Se agrega test específico que verifica que un schedule cuyo programa tiene `is_visible = false` no genera notificaciones

## Test plan

- [x] `npm test -- --testPathPattern="push.scheduler"` — 14 tests pasan (incluido el nuevo test de `is_visible = false`)
- [ ] Verificar en staging que los programas ocultos ya no aparecen en logs de notificaciones

🤖 Generated with [Claude Code](https://claude.com/claude-code)