### PR TITLE
Release 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.36.0] - 2026-06-26
+
+### Added
+
+- **`GET /subscriptions` expone estado del programa**: la respuesta ahora incluye `program.is_visible` (booleano) y `program.has_active_schedules` (booleano), para que el frontend pueda identificar visualmente los programas suscriptos que ya no están activos en la grilla.
+
 ## [1.35.0] - 2026-06-26
 
 ### Fixed

--- a/src/users/subscription.controller.ts
+++ b/src/users/subscription.controller.ts
@@ -98,6 +98,8 @@ export class SubscriptionController {
           description: sub.program.description,
           logoUrl: sub.program.logo_url, // Keep for legacy frontend support
           logo_url: sub.program.logo_url, // Add for consistency and mobile
+          is_visible: sub.program.is_visible,
+          has_active_schedules: (sub.program.schedules?.length ?? 0) > 0,
           channel: {
             id: sub.program.channel.id,
             name: sub.program.channel.name,

--- a/src/users/subscription.service.spec.ts
+++ b/src/users/subscription.service.spec.ts
@@ -214,7 +214,7 @@ describe('SubscriptionService', () => {
 
       expect(mockUserSubscriptionRepository.find).toHaveBeenCalledWith({
         where: { user: { id: mockUser.id }, isActive: true },
-        relations: ['program', 'program.channel'],
+        relations: ['program', 'program.channel', 'program.schedules'],
         order: { createdAt: 'DESC' },
       });
       expect(result).toEqual(subscriptions);

--- a/src/users/subscription.service.ts
+++ b/src/users/subscription.service.ts
@@ -121,7 +121,7 @@ export class SubscriptionService {
   async getUserSubscriptions(userId: number): Promise<UserSubscription[]> {
     return await this.subscriptionRepository.find({
       where: { user: { id: userId }, isActive: true },
-      relations: ['program', 'program.channel'],
+      relations: ['program', 'program.channel', 'program.schedules'],
       order: { createdAt: 'DESC' },
     });
   }


### PR DESCRIPTION
## [1.36.0] - 2026-06-26

### Added

- **`GET /subscriptions` expone estado del programa**: la respuesta ahora incluye `program.is_visible` (booleano) y `program.has_active_schedules` (booleano), para que el frontend pueda identificar visualmente los programas suscriptos que ya no están activos en la grilla.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)