### PR TITLE
fix: accept platform and appVersion in LoginDto and RegisterDto

### DIFF
--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -15,4 +15,14 @@ export class LoginDto {
   @IsOptional()
   @IsString()
   deviceId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  platform?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  appVersion?: string;
 }

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -37,5 +37,16 @@ export class RegisterDto {
 
   @ApiProperty({ required: false })
   @IsOptional()
+  @IsString()
   deviceId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  platform?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  appVersion?: string;
 }


### PR DESCRIPTION
## Problema

El cliente mobile enviaba `platform` y `appVersion` en el body de `/auth/login` y `/auth/register`. Con `ValidationPipe` en modo `forbidNonWhitelisted: true`, el backend rechazaba esas requests con 400, rompiendo el login y registro en la app mobile.

## Fix

Agrega `platform` y `appVersion` como campos `@IsOptional()` en `LoginDto` y `RegisterDto`. Son los mismos valores que ya se leen como headers `X-Platform` / `X-App-Version`, pero el cliente mobile los mandaba también en el body hasta que se rollée la limpieza en el lado mobile.

## Archivos cambiados

- `src/auth/dto/login.dto.ts`
- `src/auth/dto/register.dto.ts`

## Test plan

- [ ] Login desde la app mobile no devuelve 400
- [ ] Registro desde la app mobile no devuelve 400
- [ ] Login desde web (sin esos campos en el body) sigue funcionando
- [ ] Los campos son ignorados en el controller (no se usan, solo se aceptan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)