### PR TITLE
fix: handle slash-in-ID for weekly override routes (use %2F encoding)

### DIFF
--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -60,7 +60,7 @@ export class WeeklyOverridesController {
     return this.weeklyOverridesService.createWeeklyOverride(dto);
   }
 
-  @Put(':overrideId(.+)')
+  @Put(':overrideId')
   @ApiOperation({ summary: 'Update a weekly override' })
   @ApiResponse({ status: 200, description: 'Override updated successfully' })
   async updateOverride(
@@ -70,14 +70,14 @@ export class WeeklyOverridesController {
     return this.weeklyOverridesService.updateWeeklyOverride(overrideId, dto);
   }
 
-  @Get(':overrideId(.+)')
+  @Get(':overrideId')
   @ApiOperation({ summary: 'Get a specific weekly override' })
   @ApiResponse({ status: 200, description: 'Override details' })
   async getOverride(@Param('overrideId') overrideId: string) {
     return this.weeklyOverridesService.getWeeklyOverride(overrideId);
   }
 
-  @Delete(':overrideId(.+)')
+  @Delete(':overrideId')
   @ApiOperation({ summary: 'Delete a weekly override' })
   @ApiResponse({ status: 200, description: 'Override deleted successfully' })
   async deleteOverride(@Param('overrideId') overrideId: string) {

--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -33,14 +33,21 @@ export class WeeklyOverridesController {
   ) {}
 
   @Post('bulk')
-  @ApiOperation({ summary: 'Create a special program override for multiple channels at once' })
-  @ApiResponse({ status: 201, description: 'Bulk overrides created successfully' })
+  @ApiOperation({
+    summary: 'Create a special program override for multiple channels at once',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Bulk overrides created successfully',
+  })
   async createBulkOverride(@Body() dto: BulkWeeklyOverrideDto) {
     return this.weeklyOverridesService.createBulk(dto);
   }
 
   @Post('resolve-conflicts')
-  @ApiOperation({ summary: 'Resolve schedule conflicts after a linked-program override' })
+  @ApiOperation({
+    summary: 'Resolve schedule conflicts after a linked-program override',
+  })
   @ApiResponse({ status: 201, description: 'Conflicts resolved successfully' })
   async resolveConflicts(@Body() dto: ResolveConflictsDto) {
     return this.weeklyOverridesService.resolveConflicts(dto);
@@ -53,7 +60,7 @@ export class WeeklyOverridesController {
     return this.weeklyOverridesService.createWeeklyOverride(dto);
   }
 
-  @Put(':overrideId')
+  @Put(':overrideId(.+)')
   @ApiOperation({ summary: 'Update a weekly override' })
   @ApiResponse({ status: 200, description: 'Override updated successfully' })
   async updateOverride(
@@ -63,14 +70,14 @@ export class WeeklyOverridesController {
     return this.weeklyOverridesService.updateWeeklyOverride(overrideId, dto);
   }
 
-  @Get(':overrideId')
+  @Get(':overrideId(.+)')
   @ApiOperation({ summary: 'Get a specific weekly override' })
   @ApiResponse({ status: 200, description: 'Override details' })
   async getOverride(@Param('overrideId') overrideId: string) {
     return this.weeklyOverridesService.getWeeklyOverride(overrideId);
   }
 
-  @Delete(':overrideId')
+  @Delete(':overrideId(.+)')
   @ApiOperation({ summary: 'Delete a weekly override' })
   @ApiResponse({ status: 200, description: 'Override deleted successfully' })
   async deleteOverride(@Param('overrideId') overrideId: string) {


### PR DESCRIPTION
## Problema

Los IDs de weekly overrides para programas linkeados con barras en el nombre (ej. `"GHANA / PANAMÁ"`) incluyen un `/` literal en el slug. Eso hacía que `PUT/GET/DELETE /weekly-overrides/:overrideId` fallara con 404 porque Express interpretaba el slash como separador de segmento de ruta.

## Solución investigada y descartada: regex `(.+)` en el param

Se probó `@Put(':overrideId(.+)')` para que Express matchee segmentos con slash. Funcionó en runtime pero **crasheó Swagger** porque `@nestjs/swagger` usa `path-to-regexp` v8, que eliminó esa sintaxis.

## Solución adoptada: `%2F` encoding en el cliente

Express 4 (bundled con `path-to-regexp` v0.1.7) decodifica correctamente `%2F` dentro de un `:param` como un solo segmento. No requiere cambios en el backend — el cliente debe enviar el ID con slash URL-encoded.

**El backend no cambia funcionalmente.** Este PR solo documenta la investigación y aplica el reformateo de Prettier que quedó en el controller.

## Archivos cambiados

- `src/schedules/weekly-overrides.controller.ts` — reformateo de decoradores `@ApiOperation`/`@ApiResponse`

## Test plan

- [ ] `PUT /weekly-overrides/GHANA%20%2F%20PANAM%C3%81_...` resuelve correctamente
- [ ] Swagger sigue funcionando sin crashes
- [ ] `GET` y `DELETE` con ID URL-encoded también funcionan

🤖 Generated with [Claude Code](https://claude.com/claude-code)