### PR TITLE
fix: accept platform and appVersion in LoginDto and RegisterDto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.36.1] - 2026-06-27
+
+### Fixed
+
+- **Login y registro rechazados en mobile**: el `ValidationPipe` con `forbidNonWhitelisted: true` devolvía 400 cuando el cliente mobile incluía `platform` y `appVersion` en el body de `/auth/login` y `/auth/register`. Se agregaron ambos campos como `@IsOptional()` en `LoginDto` y `RegisterDto` para aceptarlos sin romper compatibilidad con web.
+
 ## [1.36.0] - 2026-06-26
 
 ### Added

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -15,4 +15,14 @@ export class LoginDto {
   @IsOptional()
   @IsString()
   deviceId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  platform?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  appVersion?: string;
 }

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -37,5 +37,16 @@ export class RegisterDto {
 
   @ApiProperty({ required: false })
   @IsOptional()
+  @IsString()
   deviceId?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  platform?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  appVersion?: string;
 }


### PR DESCRIPTION
## Problema

El cliente mobile enviaba `platform` y `appVersion` en el body de `/auth/login` y `/auth/register`. El `ValidationPipe` global con `forbidNonWhitelisted: true` rechazaba esas requests con 400, rompiendo login y registro en la app mobile.

## Fix

Agrega `platform` y `appVersion` como campos `@IsOptional()` en `LoginDto` y `RegisterDto`. Son los mismos valores que ya se leen como headers `X-Platform` / `X-App-Version`; el mobile los mandaba también en el body hasta que se limpie del lado cliente.

## Archivos cambiados

- `src/auth/dto/login.dto.ts`
- `src/auth/dto/register.dto.ts`
- `CHANGELOG.md` → v1.36.1

## Test plan

- [ ] Login desde mobile no devuelve 400
- [ ] Registro desde mobile no devuelve 400
- [ ] Login desde web (sin esos campos) sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)