### PR TITLE
⚡ Bolt: [performance improvement] Eliminate N+1 queries in bulk program creation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-05-18 - [N+1 DB Query Avoidance in bulk creation]
+**Learning:** Found N+1 query patterns inside the `createBulk` method of `ProgramsService`. For every panelist ID provided, it iterates through them using a `.map()` wrapped in a `Promise.all()`, firing an individual `.findOne()` database call for each element. This causes overhead and inefficient concurrent querying when fetching related entities en-masse.
+**Action:** Replaced the `Promise.all` + `.map()` + `.findOne()` construct with a single `.find({ where: { id: In(dto.panelist_ids) } })` operation leveraging TypeORM's `In` operator, which translates to an efficient `WHERE id IN (...)` SQL clause, retrieving all records in a single batched database round-trip.

--- a/src/migrations/1747430368000-CreateDevicesAndSubscriptions.ts
+++ b/src/migrations/1747430368000-CreateDevicesAndSubscriptions.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateDevicesAndSubscriptions1747430368000
-  implements MigrationInterface
-{
+export class CreateDevicesAndSubscriptions1747430368000 implements MigrationInterface {
   name = 'CreateDevicesAndSubscriptions1747430368000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1750000000000-AddStyleOverrideToProgram.ts
+++ b/src/migrations/1750000000000-AddStyleOverrideToProgram.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddStyleOverrideToProgram1750000000000
-  implements MigrationInterface
-{
+export class AddStyleOverrideToProgram1750000000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumn(
       'program',

--- a/src/migrations/1752000000000-CreateCategoriesAndChannelCategories.ts
+++ b/src/migrations/1752000000000-CreateCategoriesAndChannelCategories.ts
@@ -5,9 +5,7 @@ import {
   TableForeignKey,
 } from 'typeorm';
 
-export class CreateCategoriesAndChannelCategories1752000000000
-  implements MigrationInterface
-{
+export class CreateCategoriesAndChannelCategories1752000000000 implements MigrationInterface {
   name = 'CreateCategoriesAndChannelCategories1752000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1752000000001-AddIsVisibleToCategories.ts
+++ b/src/migrations/1752000000001-AddIsVisibleToCategories.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddIsVisibleToCategories1752000000001
-  implements MigrationInterface
-{
+export class AddIsVisibleToCategories1752000000001 implements MigrationInterface {
   name = 'AddIsVisibleToCategories1752000000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1753000002000-CreateUserStreamerSubscriptions.ts
+++ b/src/migrations/1753000002000-CreateUserStreamerSubscriptions.ts
@@ -6,9 +6,7 @@ import {
   TableForeignKey,
 } from 'typeorm';
 
-export class CreateUserStreamerSubscriptions1753000002000
-  implements MigrationInterface
-{
+export class CreateUserStreamerSubscriptions1753000002000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createTable(
       new Table({

--- a/src/migrations/1754000000000-BackfillChannelYouTubeConfigs.ts
+++ b/src/migrations/1754000000000-BackfillChannelYouTubeConfigs.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class BackfillChannelYouTubeConfigs1754000000000
-  implements MigrationInterface
-{
+export class BackfillChannelYouTubeConfigs1754000000000 implements MigrationInterface {
   name = 'BackfillChannelYouTubeConfigs1754000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1767142000000-AddMobileFieldsToDevices.ts
+++ b/src/migrations/1767142000000-AddMobileFieldsToDevices.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
 
-export class AddMobileFieldsToDevices1767142000000
-  implements MigrationInterface
-{
+export class AddMobileFieldsToDevices1767142000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Add fcm_token column
     await queryRunner.addColumn(

--- a/src/migrations/1771341361250-RemoveNotificationMethod.ts
+++ b/src/migrations/1771341361250-RemoveNotificationMethod.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class RemoveNotificationMethod1771341361250
-  implements MigrationInterface
-{
+export class RemoveNotificationMethod1771341361250 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     // Drop column from user_subscriptions if exists
     await queryRunner.query(

--- a/src/migrations/1779630918547-AddMonthlyScheduleFields.ts
+++ b/src/migrations/1779630918547-AddMonthlyScheduleFields.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddMonthlyScheduleFields1779630918547
-  implements MigrationInterface
-{
+export class AddMonthlyScheduleFields1779630918547 implements MigrationInterface {
   name = 'AddMonthlyScheduleFields1779630918547';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1780960227836-AddIsPremiereToProgramTable.ts
+++ b/src/migrations/1780960227836-AddIsPremiereToProgramTable.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddIsPremiereToProgramTable1780960227836
-  implements MigrationInterface
-{
+export class AddIsPremiereToProgramTable1780960227836 implements MigrationInterface {
   name = 'AddIsPremiereToProgramTable1780960227836';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/migrations/1782250703030-AddLinkGroupIdToPrograms.ts
+++ b/src/migrations/1782250703030-AddLinkGroupIdToPrograms.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddLinkGroupIdToPrograms1782250703030
-  implements MigrationInterface
-{
+export class AddLinkGroupIdToPrograms1782250703030 implements MigrationInterface {
   name = 'AddLinkGroupIdToPrograms1782250703030';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,11 +137,10 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
+      // Performance optimization: Replaced Promise.all(findOne) with a single IN query to resolve N+1 database queries
+      const panelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
       const validPanelists = panelists.filter(Boolean) as Panelist[];
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -505,9 +505,8 @@ export class SchedulesService {
             this.sentryService,
           );
           // Import dynamically to avoid circular dependency
-          const { createLiveStatusCacheFromStreams } = await import(
-            '../youtube/interfaces/live-status-cache.interface'
-          );
+          const { createLiveStatusCacheFromStreams } =
+            await import('../youtube/interfaces/live-status-cache.interface');
           const cacheData = createLiveStatusCacheFromStreams(
             channelId,
             handle,

--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -33,14 +33,21 @@ export class WeeklyOverridesController {
   ) {}
 
   @Post('bulk')
-  @ApiOperation({ summary: 'Create a special program override for multiple channels at once' })
-  @ApiResponse({ status: 201, description: 'Bulk overrides created successfully' })
+  @ApiOperation({
+    summary: 'Create a special program override for multiple channels at once',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Bulk overrides created successfully',
+  })
   async createBulkOverride(@Body() dto: BulkWeeklyOverrideDto) {
     return this.weeklyOverridesService.createBulk(dto);
   }
 
   @Post('resolve-conflicts')
-  @ApiOperation({ summary: 'Resolve schedule conflicts after a linked-program override' })
+  @ApiOperation({
+    summary: 'Resolve schedule conflicts after a linked-program override',
+  })
   @ApiResponse({ status: 201, description: 'Conflicts resolved successfully' })
   async resolveConflicts(@Body() dto: ResolveConflictsDto) {
     return this.weeklyOverridesService.resolveConflicts(dto);


### PR DESCRIPTION
💡 What: Replaced a `Promise.all` loop containing individual `.findOne` queries with a single `.find` query using the TypeORM `In` operator for fetching panelists during bulk program creation.
🎯 Why: The original implementation iterated over an array of panelist IDs and fired an independent database query for each, resulting in an O(N) "N+1 query" anti-pattern. This overhead slowed down bulk creation.
📊 Impact: Reduces database queries from O(N) (one per panelist) down to O(1) (a single batched request), significantly minimizing connection overhead and improving throughput during program bulk creation.
🔬 Measurement: Verify by executing the `ProgramsService.createBulk` method with a list of multiple `panelist_ids` and observing the database query logs; only a single `SELECT ... WHERE id IN (...)` query should be executed.

---
*PR created automatically by Jules for task [6938211994142921119](https://jules.google.com/task/6938211994142921119) started by @matiasrozenblum*