### PR TITLE
⚡ Bolt: Optimize N+1 query in panelist assignment

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2025-05-18 - [TypeORM N+1 queries in loops]
+**Learning:** Found N+1 queries inside a `Promise.all` loop in `ProgramsService.create`. Running multiple `repository.findOne` requests concurrently generates unnecessary database connections and latency.
+**Action:** Replace multiple `findOne` calls inside `Promise.all` loops with a single `repository.find({ where: { id: In(ids) } })` batch query.

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,12 +137,12 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
-      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      // ⚡ Bolt Optimization: Fixed N+1 query problem by replacing multiple `findOne`
+      // calls inside `Promise.all` with a single batch `find` using the `In` operator.
+      // Impact: Reduces N database queries to 1, significantly improving performance when assigning multiple panelists.
+      const validPanelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {
           program.panelists = validPanelists;


### PR DESCRIPTION
💡 **What**: Replaced multiple concurrent `findOne` database calls inside a `Promise.all` loop with a single `find` call using the `In` operator inside `ProgramsService`.

🎯 **Why**: Executing individual database queries inside a loop (even concurrently with `Promise.all`) creates unnecessary connection overhead and latency (a classic N+1 query problem). Fetching all panelists in a single batch query resolves this.

📊 **Impact**: Reduces database queries from N (number of panelists) to 1, significantly improving API performance and decreasing database load when saving programs with multiple panelists.

🔬 **Measurement**: Verify by creating a new program with multiple panelists via the API while monitoring the TypeORM query logs or application latency. The database should only receive a single `SELECT ... WHERE id IN (...)` query instead of multiple `SELECT ... WHERE id = X` queries.

---
*PR created automatically by Jules for task [6221318501497116373](https://jules.google.com/task/6221318501497116373) started by @matiasrozenblum*