### PR TITLE
⚡ Bolt: [Performance Improvement] Avoid N+1 DB query in ProgramsService.createBulk

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2025-05-24 - [N+1 DB Query Avoidance in ProgramsService]
+**Learning:** Found N+1 query patterns inside the `createBulk` method of `ProgramsService`. For every panelist ID, it runs `await this.panelistsRepository.findOne` concurrently wrapped in `Promise.all`. This leads to connection overhead and poor performance.
+**Action:** Replace `Promise.all` and individual `findOne` calls with a single `find` command using the `In` operator to batch the retrieval.

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,12 +137,9 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
-      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      const validPanelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {
           program.panelists = validPanelists;


### PR DESCRIPTION
💡 **What:** Refactored `ProgramsService.createBulk` to use a single `find` query with the TypeORM `In` operator instead of a `Promise.all` loop mapping over `findOne` calls for each panelist ID.
🎯 **Why:** To eliminate an N+1 database query pattern. Executing multiple concurrent `findOne` queries generates unnecessary overhead and degrades performance during bulk operations.
📊 **Impact:** Reduces database query overhead from $O(N)$ (where $N$ is the number of panelist IDs) to $O(1)$ for panelist retrieval during bulk program creation.
🔬 **Measurement:** Verified logic using a simulated mock script to confirm that the new batched retrieval accurately matches the output of the original loop-based approach. The codebase naturally de-duplicates arrays for us by the design of SQL `IN` queries.

---
*PR created automatically by Jules for task [10838634504673018393](https://jules.google.com/task/10838634504673018393) started by @matiasrozenblum*