### PR TITLE
⚡ Bolt: [performance improvement] Resolve N+1 query when assigning panelists in bulk creation

### DIFF
--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -124,6 +124,7 @@ describe('ProgramsService', () => {
 
     panelistRepository = {
       findOne: jest.fn(),
+      find: jest.fn(),
     };
 
     channelRepository = {

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,12 +137,10 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
-      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      // ⚡ Bolt: Prevent N+1 query when assigning panelists
+      const validPanelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {
           program.panelists = validPanelists;


### PR DESCRIPTION
💡 **What:** The optimization implemented replaces iterative `findOne` queries with a single batch `find` query utilizing the `In` operator inside the `ProgramsService.createBulk` method.

🎯 **Why:** The performance problem it solves is an N+1 query pattern where a separate database call was being made for each panelist ID passed in during bulk program creation, causing potential network overhead and database load bottlenecks.

📊 **Impact:** Reduces database queries when creating programs with panelists from $O(N)$ (where N is the number of panelists) down to $O(1)$ single query.

🔬 **Measurement:** Verify the execution time of `createBulk` endpoint, or trace query logs to ensure only one SELECT query is executed for the `panelist` table.

---
*PR created automatically by Jules for task [9241547609472282579](https://jules.google.com/task/9241547609472282579) started by @matiasrozenblum*