### PR TITLE
⚡ Bolt: Optimize N+1 Query in Programs Bulk Creation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+## 2025-03-24 - [N+1 DB Query Avoidance in Program Bulk Creation]
+**Learning:** Found N+1 query patterns inside the `createBulk` method of `ProgramsService`. For every assigned panelist, it executed an individual `findOne` within a `Promise.all` loop. This leads to connection overhead and poor database performance.
+**Action:** Replace `Promise.all` + `findOne` with a single `.find({ where: { id: In(...) } })` using the `In` operator to batch database retrievals. Ensure any subsequent `.filter(Boolean)` operations are removed, and update corresponding `.spec.ts` mocks to include the `.find` method.

--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -124,6 +124,7 @@ describe('ProgramsService', () => {
 
     panelistRepository = {
       findOne: jest.fn(),
+      find: jest.fn(),
     };
 
     channelRepository = {

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,12 +137,11 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
-      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      // ⚡ Bolt: Prevent N+1 DB queries by using a single .find() with In() operator
+      // Replaces Promise.all with individual .findOne() calls
+      const validPanelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {
           program.panelists = validPanelists;


### PR DESCRIPTION
💡 What: Replaced a `Promise.all` map of `findOne` operations with a single `.find({ where: { id: In(...) } })` for panelist assignment in `ProgramsService.createBulk`.
🎯 Why: Resolves a classic N+1 database query pattern that slows down bulk creation endpoints as the number of panelists increases. 
📊 Impact: Reduces database round-trips from $O(N)$ to $O(1)$ for panelist lookup operations.
🔬 Measurement: Verify through profiling TypeORM queries or logging query counts before and after the optimization during a bulk program creation involving multiple panelists.

---
*PR created automatically by Jules for task [10272739423804198054](https://jules.google.com/task/10272739423804198054) started by @matiasrozenblum*