### PR TITLE
Release 1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.38.0] - 2026-07-09
+
+### Changed
+
+- **`subscribed` por JWT en lugar de `deviceId`**: los 4 endpoints de schedules (`GET /channels/with-schedules`, `/today`, `/today/v2`, `/week`) ahora determinan el campo `subscribed` usando el `userId` del JWT cuando el header `Authorization: Bearer <token>` está presente. Esto corrige el problema multi-device donde un usuario logueado en un nuevo dispositivo no veía sus suscripciones activas.
+- Se agrega `OptionalJwtAuthGuard`: si hay JWT válido lo usa, si no hay continúa anónimamente, si el JWT es inválido/expirado devuelve 401.
+- Se mantiene fallback legacy por `deviceId` query param para versiones antiguas del mobile que aún no envían JWT — el path legado solo se activa cuando no hay JWT presente.
+
 ## [1.37.0] - 2026-06-27
 
 ### Changed

--- a/src/auth/guards/optional-jwt-auth.guard.ts
+++ b/src/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  canActivate(context: ExecutionContext) {
+    return super.canActivate(context);
+  }
+
+  handleRequest(err: any, user: any, info: any) {
+    if (err) throw err;
+    if (!user) {
+      // Reject only when a token WAS sent but is malformed, expired, or otherwise invalid.
+      // When no token is provided, passport-jwt sets info.name = 'Error' (generic) — allow anonymous.
+      const isTokenError =
+        info?.name === 'JsonWebTokenError' ||
+        info?.name === 'TokenExpiredError' ||
+        info?.name === 'NotBeforeError';
+      if (isTokenError) {
+        throw new UnauthorizedException(info.message);
+      }
+      return null;
+    }
+    return user;
+  }
+}

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -12,6 +12,9 @@ describe('ChannelsController', () => {
   let controller: ChannelsController;
   let service: ChannelsService;
 
+  // Simulate an unauthenticated request (no JWT)
+  const mockReq = { user: undefined };
+
   const mockChannel: Channel = {
     id: 1,
     name: 'Test Channel',
@@ -148,6 +151,7 @@ describe('ChannelsController', () => {
   describe('getChannelsWithSchedules', () => {
     it('should call service with correct parameters', async () => {
       const result = await controller.getChannelsWithSchedules(
+        mockReq,
         'monday',
         'device123',
         'true',
@@ -155,19 +159,24 @@ describe('ChannelsController', () => {
       );
 
       expect(result).toEqual([]);
+      // No JWT → userId=undefined, deviceId goes to legacyDeviceId (6th arg)
       expect(service.getChannelsWithSchedules).toHaveBeenCalledWith(
         'monday',
-        'device123',
+        undefined,
         true,
         'false',
+        undefined,
+        'device123',
       );
     });
 
     it('should handle undefined parameters', async () => {
-      const result = await controller.getChannelsWithSchedules();
+      const result = await controller.getChannelsWithSchedules(mockReq);
 
       expect(result).toEqual([]);
       expect(service.getChannelsWithSchedules).toHaveBeenCalledWith(
+        undefined,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -177,6 +186,7 @@ describe('ChannelsController', () => {
 
     it('should handle partial parameters', async () => {
       const result = await controller.getChannelsWithSchedules(
+        mockReq,
         'tuesday',
         undefined,
         'false',
@@ -188,6 +198,8 @@ describe('ChannelsController', () => {
         undefined,
         false,
         undefined,
+        undefined,
+        undefined,
       );
     });
   });
@@ -195,24 +207,28 @@ describe('ChannelsController', () => {
   describe('getTodaySchedules', () => {
     it('should call getTodaySchedules service method', async () => {
       const result = await controller.getTodaySchedules(
+        mockReq,
         'device123',
         'true',
         'false',
       );
 
       expect(result).toEqual([]);
+      // No JWT → userId=undefined, deviceId goes to legacyDeviceId (4th arg)
       expect(service.getTodaySchedules).toHaveBeenCalledWith(
-        'device123',
+        undefined,
         true,
         'false',
+        'device123',
       );
     });
 
     it('should handle undefined parameters', async () => {
-      const result = await controller.getTodaySchedules();
+      const result = await controller.getTodaySchedules(mockReq);
 
       expect(result).toEqual([]);
       expect(service.getTodaySchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -220,13 +236,14 @@ describe('ChannelsController', () => {
     });
 
     it('should handle partial parameters', async () => {
-      const result = await controller.getTodaySchedules('device456', 'true');
+      const result = await controller.getTodaySchedules(mockReq, 'device456', 'true');
 
       expect(result).toEqual([]);
       expect(service.getTodaySchedules).toHaveBeenCalledWith(
-        'device456',
+        undefined,
         true,
         undefined,
+        'device456',
       );
     });
   });
@@ -234,25 +251,29 @@ describe('ChannelsController', () => {
   describe('getWeekSchedules', () => {
     it('should call getWeekSchedules service method', async () => {
       const result = await controller.getWeekSchedules(
+        mockReq,
         'device123',
         'true',
         'false',
       );
 
       expect(result).toEqual([]);
+      // No JWT → userId=undefined, deviceId goes to legacyDeviceId (5th arg)
       expect(service.getWeekSchedules).toHaveBeenCalledWith(
-        'device123',
+        undefined,
         true,
         'false',
         undefined,
+        'device123',
       );
     });
 
     it('should handle undefined parameters', async () => {
-      const result = await controller.getWeekSchedules();
+      const result = await controller.getWeekSchedules(mockReq);
 
       expect(result).toEqual([]);
       expect(service.getWeekSchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -261,19 +282,21 @@ describe('ChannelsController', () => {
     });
 
     it('should handle partial parameters', async () => {
-      const result = await controller.getWeekSchedules('device789', 'false');
+      const result = await controller.getWeekSchedules(mockReq, 'device789', 'false');
 
       expect(result).toEqual([]);
       expect(service.getWeekSchedules).toHaveBeenCalledWith(
-        'device789',
+        undefined,
         false,
         undefined,
         undefined,
+        'device789',
       );
     });
 
     it('should pass weekStart param to service', async () => {
       const result = await controller.getWeekSchedules(
+        mockReq,
         undefined,
         undefined,
         undefined,
@@ -286,6 +309,7 @@ describe('ChannelsController', () => {
         undefined,
         undefined,
         '2026-06-02',
+        undefined,
       );
     });
   });

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -12,6 +12,7 @@ import {
   UploadedFile,
   BadRequestException,
   Headers,
+  Req,
 } from '@nestjs/common';
 import { needsMidnightSplit } from '../utils/app-version.util';
 import { splitCrossMidnightSchedules } from '../utils/midnight-split.util';
@@ -28,6 +29,7 @@ import {
   ApiBody,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
@@ -56,7 +58,9 @@ export class ChannelsController {
   }
 
   @Get('with-schedules')
+  @UseGuards(OptionalJwtAuthGuard)
   async getChannelsWithSchedules(
+    @Req() req: any,
     @Query('day') day?: string,
     @Query('deviceId') deviceId?: string,
     @Query('live_status') liveStatus?: string,
@@ -64,13 +68,16 @@ export class ChannelsController {
     @Headers('x-app-version') appVersion?: string,
     @Headers('origin') origin?: string,
   ) {
+    const userId = req.user ? Number(req.user.id) : undefined;
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
     const result = await this.channelsService.getChannelsWithSchedules(
       day,
-      deviceId,
+      userId,
       liveStatusBool,
       raw,
+      undefined,
+      userId ? undefined : deviceId,
     );
     if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
@@ -79,6 +86,7 @@ export class ChannelsController {
   }
 
   @Get('with-schedules/today')
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({
     summary: "Get today's schedules only (optimized for initial load)",
   })
@@ -87,18 +95,21 @@ export class ChannelsController {
     description: "Today's schedules for all channels",
   })
   async getTodaySchedules(
+    @Req() req: any,
     @Query('deviceId') deviceId?: string,
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
     @Headers('origin') origin?: string,
   ) {
+    const userId = req.user ? Number(req.user.id) : undefined;
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
     const result = await this.channelsService.getTodaySchedules(
-      deviceId,
+      userId,
       liveStatusBool,
       raw,
+      userId ? undefined : deviceId,
     );
     if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
@@ -107,6 +118,7 @@ export class ChannelsController {
   }
 
   @Get('with-schedules/today/v2')
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({
     summary: "V2: Get today's schedules with batched Redis reads (fast)",
   })
@@ -115,18 +127,21 @@ export class ChannelsController {
     description: "Today's schedules with optimized live status",
   })
   async getTodaySchedulesV2(
+    @Req() req: any,
     @Query('deviceId') deviceId?: string,
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
     @Headers('x-app-version') appVersion?: string,
     @Headers('origin') origin?: string,
   ) {
+    const userId = req.user ? Number(req.user.id) : undefined;
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
     const result = await this.channelsService.getTodaySchedulesV2(
-      deviceId,
+      userId,
       liveStatusBool,
       raw,
+      userId ? undefined : deviceId,
     );
     if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);
@@ -135,6 +150,7 @@ export class ChannelsController {
   }
 
   @Get('with-schedules/week')
+  @UseGuards(OptionalJwtAuthGuard)
   @ApiOperation({
     summary: 'Get full week schedules (optimized for background loading)',
   })
@@ -143,6 +159,7 @@ export class ChannelsController {
     description: 'Full week schedules for all channels',
   })
   async getWeekSchedules(
+    @Req() req: any,
     @Query('deviceId') deviceId?: string,
     @Query('live_status') liveStatus?: string,
     @Query('raw') raw?: string,
@@ -150,13 +167,15 @@ export class ChannelsController {
     @Headers('x-app-version') appVersion?: string,
     @Headers('origin') origin?: string,
   ) {
+    const userId = req.user ? Number(req.user.id) : undefined;
     const liveStatusBool =
       liveStatus === 'true' ? true : liveStatus === 'false' ? false : undefined;
     const result = await this.channelsService.getWeekSchedules(
-      deviceId,
+      userId,
       liveStatusBool,
       raw,
       weekStart,
+      userId ? undefined : deviceId,
     );
     if (needsMidnightSplit(appVersion, origin)) {
       return splitCrossMidnightSchedules(result);

--- a/src/channels/channels.integration.spec.ts
+++ b/src/channels/channels.integration.spec.ts
@@ -6,6 +6,7 @@ import { ChannelsService } from '../channels/channels.service';
 import { TimezoneUtil } from '../utils/timezone.util';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
 import { YoutubeLiveService } from '../channels/../youtube/youtube-live.service';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 
 describe('Channels Endpoints Integration Tests', () => {
   let app: INestApplication;
@@ -75,7 +76,10 @@ describe('Channels Endpoints Integration Tests', () => {
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(OptionalJwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
 
     app = module.createNestApplication();
     await app.init();
@@ -94,7 +98,9 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(response.body).toEqual(mockChannelWithSchedules);
+      // userId=undefined (no JWT in test), liveStatus=undefined, raw=undefined, legacyDeviceId=undefined
       expect(channelsService.getTodaySchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -112,10 +118,12 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(response.body).toEqual(mockChannelWithSchedules);
+      // No JWT → userId=undefined, deviceId goes to legacyDeviceId
       expect(channelsService.getTodaySchedules).toHaveBeenCalledWith(
-        'test-device-123',
+        undefined,
         true,
         'false',
+        'test-device-123',
       );
     });
 
@@ -131,6 +139,7 @@ describe('Channels Endpoints Integration Tests', () => {
         undefined,
         false,
         undefined,
+        undefined,
       );
     });
 
@@ -140,6 +149,7 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(channelsService.getTodaySchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -154,7 +164,9 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(response.body).toEqual(mockChannelWithSchedules);
+      // userId=undefined (no JWT), liveStatus=undefined, raw=undefined, weekStart=undefined, legacyDeviceId=undefined
       expect(channelsService.getWeekSchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -173,11 +185,13 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(response.body).toEqual(mockChannelWithSchedules);
+      // No JWT → userId=undefined, deviceId goes to legacyDeviceId
       expect(channelsService.getWeekSchedules).toHaveBeenCalledWith(
-        'test-device-456',
+        undefined,
         true,
         'true',
         undefined,
+        'test-device-456',
       );
     });
 
@@ -190,10 +204,11 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(channelsService.getWeekSchedules).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
         'partial-device',
-        undefined,
-        undefined,
-        undefined,
       );
     });
   });
@@ -210,11 +225,14 @@ describe('Channels Endpoints Integration Tests', () => {
         .expect(200);
 
       expect(response.body).toEqual(mockChannelWithSchedules);
+      // No JWT → userId=undefined, deviceId goes to legacyDeviceId (6th arg)
       expect(channelsService.getChannelsWithSchedules).toHaveBeenCalledWith(
         'tuesday',
-        'legacy-device',
+        undefined,
         true,
         undefined,
+        undefined,
+        'legacy-device',
       );
     });
 
@@ -225,6 +243,8 @@ describe('Channels Endpoints Integration Tests', () => {
 
       expect(response.body).toEqual(mockChannelWithSchedules);
       expect(channelsService.getChannelsWithSchedules).toHaveBeenCalledWith(
+        undefined,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -257,6 +277,7 @@ describe('Channels Endpoints Integration Tests', () => {
 
       // Should still call the service, but with undefined for invalid boolean
       expect(channelsService.getTodaySchedules).toHaveBeenCalledWith(
+        undefined,
         undefined,
         undefined,
         undefined,

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -11,7 +11,6 @@ import { RedisService } from '@/redis/redis.service';
 import { YoutubeDiscoveryService } from '@/youtube/youtube-discovery.service';
 import { UserSubscription } from '@/users/user-subscription.entity';
 import { Device } from '@/users/device.entity';
-import { User } from '@/users/users.entity';
 import { NotifyAndRevalidateUtil } from '../utils/notify-and-revalidate.util';
 import { ConfigService } from '@/config/config.service';
 import { WeeklyOverridesService } from '@/schedules/weekly-overrides.service';
@@ -446,10 +445,11 @@ export class ChannelsService {
 
   async getChannelsWithSchedules(
     day?: string,
-    deviceId?: string,
+    userId?: number,
     liveStatus?: boolean,
     raw?: string,
     weekStart?: string,
+    legacyDeviceId?: string,
   ): Promise<ChannelWithSchedules[]> {
     const overallStart = Date.now();
     const requestId = Math.random().toString(36).substr(2, 9);
@@ -457,18 +457,33 @@ export class ChannelsService {
       `[CHANNELS-SCHEDULES-${requestId}] Starting fetch - day: ${day || 'all'}, live: ${liveStatus}, raw: ${raw} at ${new Date().toISOString()}`,
     );
 
-    // Pre-fetch user subscriptions if deviceId is provided (optimized query)
+    // Pre-fetch user subscriptions
+    // New path: userId from JWT (direct lookup, no device indirection)
+    // Legacy path: deviceId query param → device → user (for old clients without JWT)
     let subscribedProgramIds: Set<number> = new Set();
-    if (deviceId) {
+    if (userId) {
       try {
-        // Use optimized query to avoid complex JOINs
+        const subscriptions = await this.userSubscriptionRepo.find({
+          where: { user: { id: userId }, isActive: true },
+          relations: ['program'],
+        });
+        subscribedProgramIds = new Set(
+          subscriptions.map((sub) => sub.program.id),
+        );
+      } catch (error) {
+        console.warn(
+          `[CHANNELS-SCHEDULES] Subscription lookup failed for userId ${userId}:`,
+          error.message,
+        );
+      }
+    } else if (legacyDeviceId) {
+      try {
         const device = await this.deviceRepo
           .createQueryBuilder('device')
           .leftJoinAndSelect('device.user', 'user')
           .select(['device.id', 'user.id'])
-          .where('device.deviceId = :deviceId', { deviceId })
+          .where('device.deviceId = :deviceId', { deviceId: legacyDeviceId })
           .getOne();
-
         if (device?.user?.id) {
           const subscriptions = await this.userSubscriptionRepo.find({
             where: { user: { id: device.user.id }, isActive: true },
@@ -480,10 +495,9 @@ export class ChannelsService {
         }
       } catch (error) {
         console.warn(
-          `[CHANNELS-SCHEDULES] Device lookup failed for ${deviceId}:`,
+          `[CHANNELS-SCHEDULES] Legacy device lookup failed for ${legacyDeviceId}:`,
           error.message,
         );
-        // Continue without device filtering if lookup fails
       }
     }
 
@@ -637,30 +651,33 @@ export class ChannelsService {
    * Get today's schedules only - optimized for initial page load
    */
   async getTodaySchedules(
-    deviceId?: string,
+    userId?: number,
     liveStatus?: boolean,
     raw?: string,
+    legacyDeviceId?: string,
   ): Promise<ChannelWithSchedules[]> {
     const today = TimezoneUtil.currentDayOfWeek();
 
-    return this.getChannelsWithSchedules(today, deviceId, liveStatus, raw);
+    return this.getChannelsWithSchedules(today, userId, liveStatus, raw, undefined, legacyDeviceId);
   }
 
   /**
    * Get full week schedules - optimized for background loading
    */
   async getWeekSchedules(
-    deviceId?: string,
+    userId?: number,
     liveStatus?: boolean,
     raw?: string,
     weekStart?: string,
+    legacyDeviceId?: string,
   ): Promise<ChannelWithSchedules[]> {
     return this.getChannelsWithSchedules(
       undefined,
-      deviceId,
+      userId,
       liveStatus,
       raw,
       weekStart,
+      legacyDeviceId,
     );
   }
 
@@ -670,9 +687,10 @@ export class ChannelsService {
    * (~4 round trips instead of ~150), reducing response time from ~7.5s to ~600ms.
    */
   async getTodaySchedulesV2(
-    deviceId?: string,
+    userId?: number,
     liveStatus?: boolean,
     raw?: string,
+    legacyDeviceId?: string,
   ): Promise<ChannelWithSchedules[]> {
     const overallStart = Date.now();
     const today = TimezoneUtil.currentDayOfWeek();
@@ -680,17 +698,32 @@ export class ChannelsService {
       `[CHANNELS-SCHEDULES-V2] Starting fetch - day: ${today}, live: ${liveStatus} at ${new Date().toISOString()}`,
     );
 
-    // Pre-fetch user subscriptions if deviceId is provided
+    // Pre-fetch user subscriptions
+    // New path: userId from JWT — legacy path: deviceId → device → user
     let subscribedProgramIds: Set<number> = new Set();
-    if (deviceId) {
+    if (userId) {
+      try {
+        const subscriptions = await this.userSubscriptionRepo.find({
+          where: { user: { id: userId }, isActive: true },
+          relations: ['program'],
+        });
+        subscribedProgramIds = new Set(
+          subscriptions.map((sub) => sub.program.id),
+        );
+      } catch (error) {
+        console.warn(
+          `[CHANNELS-SCHEDULES-V2] Subscription lookup failed for userId ${userId}:`,
+          error.message,
+        );
+      }
+    } else if (legacyDeviceId) {
       try {
         const device = await this.deviceRepo
           .createQueryBuilder('device')
           .leftJoinAndSelect('device.user', 'user')
           .select(['device.id', 'user.id'])
-          .where('device.deviceId = :deviceId', { deviceId })
+          .where('device.deviceId = :deviceId', { deviceId: legacyDeviceId })
           .getOne();
-
         if (device?.user?.id) {
           const subscriptions = await this.userSubscriptionRepo.find({
             where: { user: { id: device.user.id }, isActive: true },
@@ -702,7 +735,7 @@ export class ChannelsService {
         }
       } catch (error) {
         console.warn(
-          `[CHANNELS-SCHEDULES-V2] Device lookup failed for ${deviceId}:`,
+          `[CHANNELS-SCHEDULES-V2] Legacy device lookup failed for ${legacyDeviceId}:`,
           error.message,
         );
       }


### PR DESCRIPTION
## [1.38.0] - 2026-07-09

### Changed

- **`subscribed` por JWT en lugar de `deviceId`**: los 4 endpoints de schedules (`GET /channels/with-schedules`, `/today`, `/today/v2`, `/week`) ahora determinan el campo `subscribed` usando el `userId` del JWT cuando el header `Authorization: Bearer <token>` está presente. Corrige el problema multi-device donde un usuario logueado en un nuevo dispositivo no veía sus suscripciones activas.
- Se agrega `OptionalJwtAuthGuard`: si hay JWT válido lo usa, si no hay continúa anónimamente (`subscribed: false`), si el JWT es inválido/expirado devuelve 401.
- Mantiene fallback legacy por `deviceId` query param para versiones antiguas del mobile que aún no envían JWT — el path legado solo se activa cuando no hay JWT presente.