### PR TITLE
⚡ Bolt: Fix N+1 query in bulk program creation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2026-07-10 - [N+1 DB Query Avoidance in Program Bulk Creation]
+**Learning:** Found an N+1 query pattern inside the `createBulk` method of `ProgramsService` where panelists were fetched individually inside a `.map` wrapped in `Promise.all`. This causes multiple single lookups instead of batch retrieving using `In()`.
+**Action:** Replace `Promise.all` containing iterative TypeORM `.findOne` checks with a single TypeORM `.find({ where: { id: In(ids) } })` to batch DB access effectively.

--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -124,6 +124,7 @@ describe('ProgramsService', () => {
 
     panelistRepository = {
       findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
     };
 
     channelRepository = {

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,12 +137,11 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
-      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      // ⚡ Bolt Optimization: Use a single find query with In() to avoid N+1 queries
+      const validPanelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
+
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {
           program.panelists = validPanelists;


### PR DESCRIPTION
💡 **What**: Replaced a `Promise.all` loop of individual `findOne` calls for fetching panelist entities during program bulk creation with a single `find` call using the TypeORM `In()` operator.
🎯 **Why**: Executing database calls inside a loop (`.map` wrapped with `Promise.all`) creates an N+1 query problem, leading to excessive round-trips and significant performance degradation during bulk operations.
📊 **Impact**: Reduces database queries from `N` to `1` when assigning `N` panelists in a bulk create scenario. Prevents database connection exhaustion during peak load.
🔬 **Measurement**: Verified via `npm test` and mocked test execution that bulk creation continues to fetch and assign panelists efficiently without behavioral change. Evaluated through Git differences to verify loop removal.

---
*PR created automatically by Jules for task [17951324146915196014](https://jules.google.com/task/17951324146915196014) started by @matiasrozenblum*