### PR TITLE
release: seen_features onboarding API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.39.0] - 2026-07-25
+
+### Added
+- **`seen_features` en usuarios**: nueva columna `seen_features text[]` en la tabla `users` (migración `AddSeenFeaturesToUsers1783100000000`). Nuevo endpoint `POST /users/me/seen-features` (autenticado) que recibe `{ feature: string }` y agrega el feature a la lista del usuario sin duplicados. El campo se devuelve en `GET /users/me`. Permite que web y mobile sincronicen qué tooltips de onboarding ya vio el usuario entre dispositivos.
+
+---
+
 ## [1.38.0] - 2026-07-09
 
 ### Changed

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -62,7 +62,9 @@ import { ConfigModule as AppConfigModule } from './config/config.module';
           ssl: { rejectUnauthorized: false },
           schema: 'public',
           autoLoadEntities: true,
-          synchronize: false, // Temporarily disabled to prevent schema conflicts
+          synchronize: false,
+          migrations: [__dirname + '/migrations/*{.ts,.js}'],
+          migrationsRun: true,
           logging: false,
           extra: {
             max: 35, // Reduced from 50. Supabase Dedicated Pooler allows 40 per user+db. With 1 instance, 35 provides buffer while maximizing throughput. Monitor actual usage.

--- a/src/migrations/1783100000000-AddSeenFeaturesToUsers.ts
+++ b/src/migrations/1783100000000-AddSeenFeaturesToUsers.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSeenFeaturesToUsers1783100000000 implements MigrationInterface {
+  name = 'AddSeenFeaturesToUsers1783100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "seen_features" text[] NOT NULL DEFAULT '{}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" DROP COLUMN "seen_features"`,
+    );
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -83,6 +83,27 @@ export class UsersController {
     return this.usersService.findOne(req.user.id);
   }
 
+  /** Marcar feature como vista */
+  @ApiBearerAuth()
+  @Post('me/seen-features')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Marcar un feature como visto por el usuario autenticado' })
+  @ApiResponse({ status: 201, description: 'Lista actualizada de features vistos' })
+  addSeenFeature(@Req() req, @Body() body: { feature: string }) {
+    return this.usersService.addSeenFeature(req.user.id, body.feature);
+  }
+
+  /** Resetear features vistos (para testing o si el usuario quiere ver el onboarding de nuevo) */
+  @ApiBearerAuth()
+  @Delete('me/seen-features')
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: 'Resetear features vistos. Sin query param limpia todo; con ?feature=X elimina solo ese.' })
+  @ApiQuery({ name: 'feature', required: false, type: String })
+  @ApiResponse({ status: 200, description: 'Lista actualizada de features vistos' })
+  removeSeenFeature(@Req() req, @Query('feature') feature?: string) {
+    return this.usersService.removeSeenFeature(req.user.id, feature);
+  }
+
   /** Obtener usuario por ID (admin o dueño) */
   @UseGuards(JwtAuthGuard, RolesGuard) // ← agregado aquí
   @ApiBearerAuth()

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -56,6 +56,9 @@ export class User {
   })
   origin: 'traditional' | 'google' | 'facebook' | 'apple';
 
+  @Column({ type: 'text', array: true, name: 'seen_features', default: '{}' })
+  seenFeatures: string[];
+
   @OneToMany(() => Device, (device) => device.user, { cascade: true })
   devices: Device[];
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -247,6 +247,27 @@ export class UsersService {
     }
   }
 
+  async addSeenFeature(userId: number, feature: string): Promise<string[]> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) throw new NotFoundException(`User with ID ${userId} not found`);
+    if (!user.seenFeatures) user.seenFeatures = [];
+    if (!user.seenFeatures.includes(feature)) {
+      user.seenFeatures = [...user.seenFeatures, feature];
+      await this.usersRepository.save(user);
+    }
+    return user.seenFeatures;
+  }
+
+  async removeSeenFeature(userId: number, feature?: string): Promise<string[]> {
+    const user = await this.usersRepository.findOne({ where: { id: userId } });
+    if (!user) throw new NotFoundException(`User with ID ${userId} not found`);
+    user.seenFeatures = feature
+      ? (user.seenFeatures ?? []).filter((f) => f !== feature)
+      : [];
+    await this.usersRepository.save(user);
+    return user.seenFeatures;
+  }
+
   async remove(id: number): Promise<void> {
     const result = await this.usersRepository.delete(id);
     if (result.affected === 0) {


### PR DESCRIPTION
Release to production: cross-device onboarding tooltip support.

- New `seen_features text[]` column on users (migration `AddSeenFeaturesToUsers1783100000000`)
- `POST /users/me/seen-features` and `DELETE /users/me/seen-features`
- TypeORM `migrationsRun: true` — migration runs automatically on deploy

Prod migrations table verified current (last = AddLinkGroupIdToPrograms1782250703030); exactly one migration will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)