### PR TITLE
Release 1.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.40.0] - 2026-07-29
+
+### Added
+- **Overtime — los programas siguen en vivo mientras la transmisión no corte**: `is_live` se decidía únicamente por la ventana horaria del schedule, así que un programa cargado de 13:00 a 15:00 pasaba a no-live a las 15:00 en punto aunque su stream siguiera al aire. El usuario que había cerrado el reproductor no tenía forma de volver: el bloque ofrecía "Ver en YouTube" en vez del vivo, y el canal desaparecía de la lista de zapping. Además el cron solo consultaba canales con un programa al aire, así que terminado el bloque nadie refrescaba el caché y expiraba.
+
+  Ahora un programa se mantiene en vivo pasado su horario mientras el stream específico que tenía asignado siga transmitiendo, con un tope de 180 minutos, y deja de extenderse apenas otro programa toma el canal. Los programas en overtime exponen `live_overtime: true` junto a `is_live`, y su `stream_url` apunta a la transmisión en curso en lugar del link de canal o playlist guardado en el programa.
+
+  - La validación usa `isVideoLive` (`videos.list`, 1 unidad de quota) y nunca el camino de refresh basado en `search.list`: la quota escasa es "Search Queries per day" (398/día), no "Queries per day" (50.000). Mandar los canales en overtime al refresh normal la habría agotado en una tarde.
+  - Nuevo marcador Redis `lastLiveVideo:{handle}`, que sobrevive al TTL alineado al bloque — ese TTL expira justo cuando el overtime lo necesita — para que siempre haya un `videoId` que validar.
+  - El overtime se keyea por `scheduleId` string, así que los programas especiales de weekly overrides (ids virtuales `virtual_<overrideId>`) quedan cubiertos.
+  - Se notifica por SSE en las dos transiciones (inicio y fin) para que los clientes refresquen en segundos en vez de esperar hasta 5 minutos a su próximo poll. La notificación se escribe como objeto plano: `RedisService.set` ya serializa, y el doble encoding de los call sites viejos hace que el controller SSE la parsee de vuelta a string y colapse todas las notificaciones en el mismo id de dedup.
+
+---
+
 ## [1.39.0] - 2026-07-25
 
 ### Added

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -29,6 +29,7 @@ describe('AuthController', () => {
     isActive: true,
     lastLogin: new Date(),
     origin: 'traditional' as const,
+    seenFeatures: [],
     devices: [],
     subscriptions: [],
     streamerSubscriptions: [],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -28,6 +28,7 @@ describe('AuthService', () => {
     isActive: true,
     lastLogin: new Date(),
     origin: 'traditional' as const,
+    seenFeatures: [],
     devices: [],
     subscriptions: [],
     streamerSubscriptions: [],

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -57,6 +57,8 @@ type ChannelWithSchedules = {
       description: string | null;
       stream_url: string | null;
       is_live: boolean;
+      /** Live past its scheduled end because the stream is still running. */
+      live_overtime?: boolean;
       live_streams?: any[] | null;
       stream_count?: number;
       channel_stream_count?: number;
@@ -623,6 +625,7 @@ export class ChannelsService {
               description: schedule.program.description,
               stream_url: schedule.program.stream_url,
               is_live: schedule.program.is_live,
+              live_overtime: schedule.program.live_overtime ?? false,
               live_streams: schedule.program.live_streams,
               stream_count: schedule.program.stream_count,
               channel_stream_count: schedule.program.channel_stream_count,
@@ -826,6 +829,7 @@ export class ChannelsService {
             description: schedule.program.description,
             stream_url: schedule.program.stream_url,
             is_live: schedule.program.is_live,
+            live_overtime: schedule.program.live_overtime ?? false,
             live_streams: schedule.program.live_streams,
             stream_count: schedule.program.stream_count,
             channel_stream_count: schedule.program.channel_stream_count,

--- a/src/users/device.service.spec.ts
+++ b/src/users/device.service.spec.ts
@@ -21,6 +21,7 @@ describe('DeviceService', () => {
     birthDate: new Date('1990-01-01'),
     createdAt: new Date(),
     origin: 'traditional',
+    seenFeatures: [],
     devices: [],
     subscriptions: [],
     streamerSubscriptions: [],

--- a/src/users/subscription.service.spec.ts
+++ b/src/users/subscription.service.spec.ts
@@ -27,6 +27,7 @@ describe('SubscriptionService', () => {
     birthDate: new Date('1990-01-01'),
     createdAt: new Date(),
     origin: 'traditional',
+    seenFeatures: [],
     devices: [],
     subscriptions: [],
     streamerSubscriptions: [],

--- a/src/youtube/interfaces/live-status-cache.interface.ts
+++ b/src/youtube/interfaces/live-status-cache.interface.ts
@@ -12,6 +12,21 @@ export interface LiveStream {
   liveBroadcastContent?: string; // 'live', 'upcoming', or 'none'
 }
 
+/**
+ * A program whose scheduled block already ended but whose assigned stream is
+ * still broadcasting. Keyed by scheduleId so the extension follows the specific
+ * program that owned the stream, not the channel as a whole.
+ *
+ * scheduleId is a string because special programs created via weekly overrides
+ * use virtual ids (`virtual_<overrideId>`) rather than numeric DB ids.
+ */
+export interface OvertimeEntry {
+  scheduleId: string;
+  videoId: string;
+  streamUrl: string;
+  startedAt: number;
+}
+
 export interface LiveStatusCache {
   channelId: string;
   handle: string;
@@ -20,6 +35,8 @@ export interface LiveStatusCache {
   videoId: string | null;
   lastUpdated: number;
   ttl: number;
+  /** Programs past their scheduled end that are still on air. */
+  overtime?: OvertimeEntry[];
   // Block-aware fields for accurate timing
   blockEndTime: number | null; // When the current block ends (in minutes), null if unknown
   validationCooldown: number; // When we can validate again (timestamp)

--- a/src/youtube/live-status-background.service.overtime.spec.ts
+++ b/src/youtube/live-status-background.service.overtime.spec.ts
@@ -1,0 +1,261 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { LiveStatusBackgroundService } from './live-status-background.service';
+import { YoutubeLiveService } from './youtube-live.service';
+import { SchedulesService } from '../schedules/schedules.service';
+import { RedisService } from '../redis/redis.service';
+import { ConfigService } from '../config/config.service';
+import { SentryService } from '../sentry/sentry.service';
+import { Channel } from '../channels/channels.entity';
+
+/**
+ * Overtime: a program whose scheduled block ended but whose stream is still
+ * broadcasting stays live so viewers who closed the player can get back to it.
+ */
+describe('LiveStatusBackgroundService — overtime', () => {
+  let service: LiveStatusBackgroundService;
+  let youtubeLiveService: jest.Mocked<YoutubeLiveService>;
+  let redisService: any;
+  let configService: any;
+  let channelsRepository: any;
+
+  const HANDLE = 'testchannel';
+  const CHANNEL_ID = 'CHANNEL_123';
+  const LAST_LIVE_KEY = `lastLiveVideo:${HANDLE}`;
+  const STATUS_KEY = `liveStatusByHandle:${HANDLE}`;
+
+  const buildMarker = (overrides: Record<string, any> = {}) => ({
+    channelId: CHANNEL_ID,
+    handle: HANDLE,
+    scheduleId: '42',
+    programName: 'Programa de las 13',
+    videoId: 'VIDEO_123',
+    streamUrl: 'https://www.youtube.com/embed/VIDEO_123?autoplay=1',
+    stream: { videoId: 'VIDEO_123', title: 'Programa de las 13 — EN VIVO' },
+    overtimeStartedAt: null,
+    updatedAt: Date.now(),
+    ...overrides,
+  });
+
+  const runOvertime = (liveChannelIds: string[] = []) =>
+    (service as any).processOvertimeChannels(new Set(liveChannelIds));
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LiveStatusBackgroundService,
+        {
+          provide: YoutubeLiveService,
+          useValue: { isVideoLive: jest.fn() },
+        },
+        { provide: SchedulesService, useValue: { findAll: jest.fn() } },
+        {
+          provide: RedisService,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+            mget: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { canFetchLive: jest.fn().mockResolvedValue(true) },
+        },
+        { provide: SentryService, useValue: { captureException: jest.fn() } },
+        {
+          provide: getRepositoryToken(Channel),
+          useValue: { find: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(LiveStatusBackgroundService);
+    youtubeLiveService = module.get(YoutubeLiveService);
+    redisService = module.get(RedisService);
+    configService = module.get(ConfigService);
+    channelsRepository = module.get(getRepositoryToken(Channel));
+
+    channelsRepository.find.mockResolvedValue([
+      { handle: HANDLE, youtube_channel_id: CHANNEL_ID },
+    ]);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('keeps the program live when its stream is still broadcasting', async () => {
+    redisService.mget.mockResolvedValue([buildMarker()]);
+    youtubeLiveService.isVideoLive.mockResolvedValue(true);
+
+    await runOvertime();
+
+    expect(youtubeLiveService.isVideoLive).toHaveBeenCalledWith('VIDEO_123');
+    expect(redisService.set).toHaveBeenCalledWith(
+      STATUS_KEY,
+      expect.objectContaining({
+        isLive: true,
+        videoId: 'VIDEO_123',
+        streamUrl: 'https://www.youtube.com/embed/VIDEO_123?autoplay=1',
+        overtime: [
+          expect.objectContaining({ scheduleId: '42', videoId: 'VIDEO_123' }),
+        ],
+      }),
+      150,
+    );
+  });
+
+  it('ends overtime and publishes not-live once the stream stops', async () => {
+    redisService.mget.mockResolvedValue([buildMarker()]);
+    youtubeLiveService.isVideoLive.mockResolvedValue(false);
+
+    await runOvertime();
+
+    expect(redisService.del).toHaveBeenCalledWith(LAST_LIVE_KEY);
+    expect(redisService.set).toHaveBeenCalledWith(
+      STATUS_KEY,
+      expect.objectContaining({ isLive: false, videoId: null }),
+      expect.any(Number),
+    );
+  });
+
+  it('does not extend a channel that already handed over to the next program', async () => {
+    redisService.mget.mockResolvedValue([buildMarker()]);
+
+    // Channel has a program on air right now.
+    await runOvertime([CHANNEL_ID]);
+
+    expect(redisService.mget).not.toHaveBeenCalled();
+    expect(youtubeLiveService.isVideoLive).not.toHaveBeenCalled();
+  });
+
+  it('stops extending once the cap is reached, without spending quota', async () => {
+    redisService.mget.mockResolvedValue([
+      buildMarker({ overtimeStartedAt: Date.now() - 181 * 60 * 1000 }),
+    ]);
+
+    await runOvertime();
+
+    expect(youtubeLiveService.isVideoLive).not.toHaveBeenCalled();
+    expect(redisService.del).toHaveBeenCalledWith(LAST_LIVE_KEY);
+  });
+
+  it('does not extend channels with live fetching disabled', async () => {
+    redisService.mget.mockResolvedValue([buildMarker()]);
+    configService.canFetchLive.mockResolvedValue(false);
+
+    await runOvertime();
+
+    expect(youtubeLiveService.isVideoLive).not.toHaveBeenCalled();
+    expect(redisService.del).toHaveBeenCalledWith(LAST_LIVE_KEY);
+  });
+
+  it('preserves the start time across cycles instead of resetting the cap', async () => {
+    const startedAt = Date.now() - 30 * 60 * 1000;
+    redisService.mget.mockResolvedValue([
+      buildMarker({ overtimeStartedAt: startedAt }),
+    ]);
+    youtubeLiveService.isVideoLive.mockResolvedValue(true);
+
+    await runOvertime();
+
+    expect(redisService.set).toHaveBeenCalledWith(
+      STATUS_KEY,
+      expect.objectContaining({
+        overtime: [expect.objectContaining({ startedAt })],
+      }),
+      150,
+    );
+  });
+
+  it('supports special weekly programs, whose schedule ids are virtual strings', async () => {
+    redisService.mget.mockResolvedValue([
+      buildMarker({ scheduleId: 'virtual_special_channel_7_especial_monday' }),
+    ]);
+    youtubeLiveService.isVideoLive.mockResolvedValue(true);
+
+    await runOvertime();
+
+    expect(redisService.set).toHaveBeenCalledWith(
+      STATUS_KEY,
+      expect.objectContaining({
+        overtime: [
+          expect.objectContaining({
+            scheduleId: 'virtual_special_channel_7_especial_monday',
+          }),
+        ],
+      }),
+      150,
+    );
+  });
+
+  describe('SSE notifications', () => {
+    const notificationWrites = () =>
+      redisService.set.mock.calls.filter((call: any[]) =>
+        String(call[0]).startsWith('live_notification:'),
+      );
+
+    it('announces the start of overtime so clients refresh immediately', async () => {
+      redisService.mget.mockResolvedValue([buildMarker()]);
+      youtubeLiveService.isVideoLive.mockResolvedValue(true);
+
+      await runOvertime();
+
+      const [call] = notificationWrites();
+      expect(call[0]).toMatch(/^live_notification:CHANNEL_123:\d+$/);
+      // Plain object: RedisService.set serialises it. Double-encoding would
+      // collapse every notification onto the same dedup id downstream.
+      expect(call[1]).toEqual(
+        expect.objectContaining({
+          type: 'live_status_changed',
+          channelId: CHANNEL_ID,
+          videoId: 'VIDEO_123',
+        }),
+      );
+    });
+
+    it('announces the end of overtime', async () => {
+      redisService.mget.mockResolvedValue([
+        buildMarker({ overtimeStartedAt: Date.now() - 20 * 60 * 1000 }),
+      ]);
+      youtubeLiveService.isVideoLive.mockResolvedValue(false);
+
+      await runOvertime();
+
+      expect(notificationWrites()[0][1]).toEqual(
+        expect.objectContaining({
+          type: 'live_status_changed',
+          videoId: null,
+        }),
+      );
+    });
+
+    it('stays quiet while overtime simply continues', async () => {
+      redisService.mget.mockResolvedValue([
+        buildMarker({ overtimeStartedAt: Date.now() - 20 * 60 * 1000 }),
+      ]);
+      youtubeLiveService.isVideoLive.mockResolvedValue(true);
+
+      await runOvertime();
+
+      expect(notificationWrites()).toHaveLength(0);
+    });
+
+    it('stays quiet when the stream was already down before overtime began', async () => {
+      redisService.mget.mockResolvedValue([buildMarker()]);
+      youtubeLiveService.isVideoLive.mockResolvedValue(false);
+
+      await runOvertime();
+
+      expect(notificationWrites()).toHaveLength(0);
+    });
+  });
+
+  it('skips channels with no recorded stream', async () => {
+    redisService.mget.mockResolvedValue([null]);
+
+    await runOvertime();
+
+    expect(youtubeLiveService.isVideoLive).not.toHaveBeenCalled();
+    expect(redisService.set).not.toHaveBeenCalled();
+  });
+});

--- a/src/youtube/live-status-background.service.ts
+++ b/src/youtube/live-status-background.service.ts
@@ -20,6 +20,30 @@ interface LiveStream {
   publishedAt?: string;
 }
 
+interface OvertimeEntry {
+  scheduleId: string;
+  videoId: string;
+  streamUrl: string;
+  startedAt: number;
+}
+
+/**
+ * Snapshot of the last stream known to be live on a channel, kept alive well
+ * past the block TTL so the overtime pass still has a videoId to validate once
+ * the regular live-status cache has expired.
+ */
+interface LastLiveVideoMarker {
+  channelId: string;
+  handle: string;
+  scheduleId: string;
+  programName: string;
+  videoId: string;
+  streamUrl: string;
+  stream: LiveStream | null;
+  overtimeStartedAt: number | null;
+  updatedAt: number;
+}
+
 interface LiveStatusCache {
   channelId: string;
   handle: string;
@@ -28,6 +52,7 @@ interface LiveStatusCache {
   videoId: string | null;
   lastUpdated: number;
   ttl: number;
+  overtime?: OvertimeEntry[];
   // Block-aware fields for accurate timing
   blockEndTime: number | null; // When the current block ends (in minutes), null if unknown
   validationCooldown: number; // When we can validate again (timestamp)
@@ -42,6 +67,16 @@ export class LiveStatusBackgroundService {
   private readonly logger = new Logger(LiveStatusBackgroundService.name);
   private readonly CACHE_PREFIX = 'liveStatusByHandle:'; // Migration complete
   private readonly CACHE_TTL = 5 * 60; // 5 minutes default TTL
+
+  // ── Overtime: programs still on air after their scheduled block ended ──
+  private readonly LAST_LIVE_PREFIX = 'lastLiveVideo:';
+  /** Hard cap on how long a program may extend past its scheduled end. */
+  private readonly OVERTIME_MAX_MINUTES = 180;
+  /**
+   * Short TTL for overtime cache entries. The block-aligned TTL is meaningless
+   * here — the block is over — so we re-validate every cron cycle instead.
+   */
+  private readonly OVERTIME_TTL = 150; // 2.5 minutes (cron runs every 2)
 
   constructor(
     private readonly youtubeLiveService: YoutubeLiveService,
@@ -149,6 +184,15 @@ export class LiveStatusBackgroundService {
           continue;
         }
 
+        // A program is on air on this channel, so any overtime left over from
+        // the previous one is stale. Drop it now — updateChannelLiveStatus has
+        // paths that mutate and re-save the cached object, which would
+        // otherwise carry it forward and light up two programs at once.
+        if (cached.overtime?.length) {
+          delete cached.overtime;
+          await this.cacheLiveStatus(channelId, cached);
+        }
+
         // Find current program name for this channel
         const currentSchedule = allSchedules.find((schedule) => {
           const scheduleChannelId =
@@ -165,6 +209,10 @@ export class LiveStatusBackgroundService {
           );
         });
         const currentProgramName = currentSchedule?.program?.name || '';
+
+        // Remember the stream currently on air so the overtime pass can keep
+        // validating it after the block-aligned cache TTL expires.
+        await this.recordLastLiveVideo(cached, currentSchedule);
 
         // Check if title matching is disabled for this channel
         // Some channels use a single unified live stream for all programs
@@ -199,14 +247,18 @@ export class LiveStatusBackgroundService {
 
       if (channelsToUpdate.length === 0) {
         this.logger.log('✅ All channels up to date, skipping update');
-        return;
+      } else {
+        // Update live status for channels in batches
+        await this.updateChannelsInBatches(channelsToUpdate);
+
+        // Update unified enriched cache with fresh live status
+        await this.updateLiveStatusForAllChannels();
       }
 
-      // Update live status for channels in batches
-      await this.updateChannelsInBatches(channelsToUpdate);
-
-      // Update unified enriched cache with fresh live status
-      await this.updateLiveStatusForAllChannels();
+      // Channels with no program on air right now may still be broadcasting the
+      // stream of a program that just ended. This runs on every cycle, including
+      // when nothing above needed an update.
+      await this.processOvertimeChannels(new Set(liveChannels.keys()));
 
       const duration = Date.now() - startTime;
       this.logger.log(
@@ -234,6 +286,244 @@ export class LiveStatusBackgroundService {
     }
 
     return null;
+  }
+
+  /**
+   * Persist the stream currently on air for a channel.
+   *
+   * The regular live-status cache uses a block-aligned TTL, so it expires right
+   * about when the program ends — exactly when the overtime pass needs it. This
+   * marker outlives the block so we always have a videoId to validate.
+   */
+  private async recordLastLiveVideo(
+    cached: LiveStatusCache,
+    currentSchedule:
+      | { id: number | string; program?: { name?: string } }
+      | undefined,
+  ): Promise<void> {
+    if (!cached.isLive || !cached.videoId || !cached.handle) return;
+    if (!currentSchedule?.id) return;
+
+    const key = `${this.LAST_LIVE_PREFIX}${cached.handle}`;
+    const existing = await this.redisService.get<LastLiveVideoMarker>(key);
+
+    const marker: LastLiveVideoMarker = {
+      channelId: cached.channelId,
+      handle: cached.handle,
+      // String: special programs from weekly overrides use `virtual_<id>` ids.
+      scheduleId: String(currentSchedule.id),
+      programName: currentSchedule.program?.name || '',
+      videoId: cached.videoId,
+      streamUrl:
+        cached.streamUrl ||
+        `https://www.youtube.com/embed/${cached.videoId}?autoplay=1`,
+      stream: cached.streams?.[0] ?? existing?.stream ?? null,
+      // The program is on air right now, so it is not in overtime yet.
+      overtimeStartedAt: null,
+      updatedAt: Date.now(),
+    };
+
+    await this.redisService.set(
+      key,
+      marker,
+      (this.OVERTIME_MAX_MINUTES + 10) * 60,
+    );
+  }
+
+  /**
+   * Keep programs live past their scheduled end while their stream is still up.
+   *
+   * Only runs for channels with nothing on air right now — a channel whose next
+   * program already started has handed the stream over, so the previous program
+   * must not extend.
+   */
+  private async processOvertimeChannels(
+    liveChannelIds: Set<string>,
+  ): Promise<void> {
+    try {
+      const channels = await this.channelsRepository.find();
+      const candidates = channels.filter(
+        (c) =>
+          c.handle &&
+          c.youtube_channel_id &&
+          !liveChannelIds.has(c.youtube_channel_id),
+      );
+      if (candidates.length === 0) return;
+
+      const markers = await this.redisService.mget<LastLiveVideoMarker>(
+        candidates.map((c) => `${this.LAST_LIVE_PREFIX}${c.handle}`),
+      );
+
+      const pending = markers.filter(
+        (m): m is LastLiveVideoMarker => !!m?.videoId && !!m.handle,
+      );
+      if (pending.length === 0) return;
+
+      let extended = 0;
+      let ended = 0;
+      for (const marker of pending) {
+        const result = await this.resolveOvertimeForChannel(marker);
+        if (result === 'extended') extended++;
+        else if (result === 'ended') ended++;
+      }
+
+      this.logger.log(
+        `⏱️  Overtime pass: ${pending.length} candidates, ${extended} still on air, ${ended} ended`,
+      );
+    } catch (error) {
+      this.logger.error('❌ Error in overtime pass:', error);
+    }
+  }
+
+  /**
+   * Decide whether a single channel's just-ended program is still broadcasting.
+   *
+   * Uses `isVideoLive` (videos.list, 1 quota unit) rather than the search-based
+   * refresh path — the daily search budget is the scarce one and must not be
+   * spent on polling programs that already ended.
+   */
+  private async resolveOvertimeForChannel(
+    marker: LastLiveVideoMarker,
+  ): Promise<'extended' | 'ended' | 'skipped'> {
+    const key = `${this.LAST_LIVE_PREFIX}${marker.handle}`;
+
+    // Same guards as the regular path: disabled channels, holidays.
+    let canFetch = true;
+    try {
+      canFetch = await this.configService.canFetchLive(marker.handle);
+    } catch {
+      this.logger.debug(
+        `[OVERTIME] Could not read fetch config for ${marker.handle}, skipping`,
+      );
+      canFetch = false;
+    }
+    if (!canFetch) {
+      await this.endOvertime(marker, key);
+      return 'skipped';
+    }
+
+    // On the first overtime cycle, fall back to the last time we confirmed the
+    // program was on air — effectively its block end. Anchoring to `now` instead
+    // would restart the cap from zero after any gap in cron execution.
+    const startedAt =
+      marker.overtimeStartedAt ?? marker.updatedAt ?? Date.now();
+    const elapsedMinutes = (Date.now() - startedAt) / 60000;
+    if (elapsedMinutes > this.OVERTIME_MAX_MINUTES) {
+      this.logger.log(
+        `[OVERTIME] Cap reached for ${marker.handle} (${Math.round(elapsedMinutes)}min), ending overtime for "${marker.programName}"`,
+      );
+      await this.endOvertime(marker, key);
+      return 'ended';
+    }
+
+    const stillLive = await this.youtubeLiveService.isVideoLive(marker.videoId);
+    if (!stillLive) {
+      this.logger.log(
+        `[OVERTIME] Stream ${marker.videoId} ended for ${marker.handle} ("${marker.programName}")`,
+      );
+      await this.endOvertime(marker, key);
+      return 'ended';
+    }
+
+    const cacheData: LiveStatusCache = {
+      channelId: marker.channelId,
+      handle: marker.handle,
+      isLive: true,
+      streamUrl: marker.streamUrl,
+      videoId: marker.videoId,
+      lastUpdated: Date.now(),
+      ttl: this.OVERTIME_TTL,
+      overtime: [
+        {
+          scheduleId: marker.scheduleId,
+          videoId: marker.videoId,
+          streamUrl: marker.streamUrl,
+          startedAt,
+        },
+      ],
+      // The block is over, so there is no meaningful block end to track.
+      blockEndTime: null,
+      validationCooldown: Date.now() + this.OVERTIME_TTL * 1000,
+      lastValidation: Date.now(),
+      streams: marker.stream ? [marker.stream] : [],
+      streamCount: marker.stream ? 1 : 0,
+    };
+    await this.cacheLiveStatus(marker.channelId, cacheData);
+
+    const isFirstCycle = marker.overtimeStartedAt === null;
+
+    await this.redisService.set(
+      key,
+      { ...marker, overtimeStartedAt: startedAt, updatedAt: Date.now() },
+      (this.OVERTIME_MAX_MINUTES + 10) * 60,
+    );
+
+    if (isFirstCycle) {
+      await this.notifyOvertimeChange(marker, marker.videoId);
+    }
+
+    this.logger.debug(
+      `[OVERTIME] "${marker.programName}" (${marker.handle}) still on air, ${Math.round(elapsedMinutes)}min past its block`,
+    );
+    return 'extended';
+  }
+
+  /**
+   * Drop the overtime marker and publish a not-live status so clients stop
+   * showing the program as live instead of waiting for the entry to expire.
+   */
+  private async endOvertime(
+    marker: LastLiveVideoMarker,
+    key: string,
+  ): Promise<void> {
+    await this.redisService.del(key);
+    await this.cacheLiveStatus(
+      marker.channelId,
+      this.createNotLiveCacheData(
+        marker.channelId,
+        marker.handle,
+        this.CACHE_TTL,
+      ),
+    );
+
+    // Only worth telling clients when they were actually shown the overtime.
+    if (marker.overtimeStartedAt !== null) {
+      await this.notifyOvertimeChange(marker, null);
+    }
+  }
+
+  /**
+   * Push an SSE notification so clients refresh right away instead of waiting
+   * up to 5 minutes for their next poll. Fired only on overtime transitions,
+   * never on the steady-state re-validation that runs every cycle.
+   *
+   * The payload goes in as an object because RedisService.set already
+   * serialises it. Double-encoding (as the older call sites do) makes the SSE
+   * controller parse it back into a string, which collapses every notification
+   * onto the same dedup id and silently drops all but the first.
+   */
+  private async notifyOvertimeChange(
+    marker: LastLiveVideoMarker,
+    videoId: string | null,
+  ): Promise<void> {
+    try {
+      const timestamp = Date.now();
+      await this.redisService.set(
+        `live_notification:${marker.channelId}:${timestamp}`,
+        {
+          type: 'live_status_changed',
+          channelId: marker.channelId,
+          videoId,
+          channelName: marker.handle,
+          timestamp,
+        },
+        300,
+      );
+    } catch {
+      this.logger.warn(
+        `[OVERTIME] Could not publish SSE notification for ${marker.handle}`,
+      );
+    }
   }
 
   /**

--- a/src/youtube/optimized-schedules.service.overtime.spec.ts
+++ b/src/youtube/optimized-schedules.service.overtime.spec.ts
@@ -1,0 +1,180 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OptimizedSchedulesService } from './optimized-schedules.service';
+import { SchedulesService } from '../schedules/schedules.service';
+import { WeeklyOverridesService } from '../schedules/weekly-overrides.service';
+import { RedisService } from '../redis/redis.service';
+
+// "Now" is Monday 15:15 — just past a 13:00–15:00 block.
+jest.mock('../utils/timezone.util', () => ({
+  TimezoneUtil: {
+    currentDayOfWeek: jest.fn().mockReturnValue('monday'),
+    previousDayOfWeek: jest.fn().mockReturnValue('sunday'),
+    currentTimeInMinutes: jest.fn().mockReturnValue(915),
+    currentDateString: jest.fn().mockReturnValue('2026-07-27'),
+    isTimeInRange: jest.fn((start: number, end: number, current: number) => {
+      if (end <= start) return current >= start || current < end;
+      return current >= start && current < end;
+    }),
+  },
+}));
+
+describe('OptimizedSchedulesService — overtime enrichment', () => {
+  let service: OptimizedSchedulesService;
+  let redisService: any;
+
+  const CHANNEL_ID = 'CHANNEL_123';
+  const HANDLE = 'testchannel';
+  const OVERTIME_URL = 'https://www.youtube.com/embed/VIDEO_123?autoplay=1';
+
+  const buildSchedule = (overrides: Record<string, any> = {}) => ({
+    id: 42,
+    day_of_week: 'monday',
+    start_time: '13:00',
+    end_time: '15:00',
+    program: {
+      id: 7,
+      name: 'Programa de las 13',
+      is_visible: true,
+      stream_url: 'https://www.youtube.com/@testchannel',
+      youtube_url: null,
+      channel: {
+        youtube_channel_id: CHANNEL_ID,
+        handle: HANDLE,
+        is_visible: true,
+      },
+    },
+    ...overrides,
+  });
+
+  const buildLiveStatus = (overtime: any[] | undefined) => ({
+    channelId: CHANNEL_ID,
+    handle: HANDLE,
+    isLive: !!overtime?.length,
+    streamUrl: OVERTIME_URL,
+    videoId: 'VIDEO_123',
+    overtime,
+    streams: [{ videoId: 'VIDEO_123', title: 'Programa de las 13' }],
+    streamCount: 1,
+  });
+
+  const enrich = (schedules: any[], liveStatus: any) => {
+    redisService.mget.mockImplementation((keys: string[]) => {
+      const prefix = keys[0] ?? '';
+      if (prefix.startsWith('liveStatusByHandle:')) {
+        return Promise.resolve([liveStatus]);
+      }
+      return Promise.resolve(keys.map(() => null));
+    });
+    return (service as any).enrichWithCachedLiveStatusFast(schedules);
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OptimizedSchedulesService,
+        { provide: SchedulesService, useValue: { findAll: jest.fn() } },
+        {
+          provide: WeeklyOverridesService,
+          useValue: {
+            applyWeeklyOverrides: jest.fn(),
+            getWeekStartDate: jest.fn(),
+          },
+        },
+        {
+          provide: RedisService,
+          useValue: {
+            mget: jest.fn(),
+            // Global fetch_enabled true, no holiday configured.
+            get: jest.fn((key: string) =>
+              Promise.resolve(
+                key === 'config:fetch_enabled:youtube.fetch_enabled'
+                  ? true
+                  : null,
+              ),
+            ),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(OptimizedSchedulesService);
+    redisService = module.get(RedisService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('keeps a finished program live while its stream is in overtime', async () => {
+    const overtime = [
+      { scheduleId: '42', videoId: 'VIDEO_123', streamUrl: OVERTIME_URL },
+    ];
+
+    const [result] = await enrich([buildSchedule()], buildLiveStatus(overtime));
+
+    expect(result.program.is_live).toBe(true);
+    expect(result.program.live_overtime).toBe(true);
+    // Not the program's stored channel link — the actual running broadcast.
+    expect(result.program.stream_url).toBe(OVERTIME_URL);
+  });
+
+  it('does not extend when another program already took over the channel', async () => {
+    const overtime = [
+      { scheduleId: '42', videoId: 'VIDEO_123', streamUrl: OVERTIME_URL },
+    ];
+    const nextProgram = buildSchedule({
+      id: 43,
+      start_time: '15:00',
+      end_time: '17:00',
+    });
+
+    const results = await enrich(
+      [buildSchedule(), nextProgram],
+      buildLiveStatus(overtime),
+    );
+
+    const finished = results.find((r: any) => r.id === 42);
+    const onAir = results.find((r: any) => r.id === 43);
+
+    expect(finished.program.is_live).toBe(false);
+    expect(finished.program.live_overtime).toBe(false);
+    expect(onAir.program.is_live).toBe(true);
+  });
+
+  it('ignores overtime belonging to a different program', async () => {
+    const overtime = [
+      { scheduleId: '99', videoId: 'VIDEO_999', streamUrl: OVERTIME_URL },
+    ];
+
+    const [result] = await enrich([buildSchedule()], buildLiveStatus(overtime));
+
+    expect(result.program.is_live).toBe(false);
+    expect(result.program.live_overtime).toBe(false);
+  });
+
+  it('matches virtual schedule ids used by special weekly programs', async () => {
+    const virtualId = 'virtual_special_channel_7_especial_monday';
+    const overtime = [
+      { scheduleId: virtualId, videoId: 'VIDEO_123', streamUrl: OVERTIME_URL },
+    ];
+
+    const [result] = await enrich(
+      [buildSchedule({ id: virtualId })],
+      buildLiveStatus(overtime),
+    );
+
+    expect(result.program.is_live).toBe(true);
+    expect(result.program.live_overtime).toBe(true);
+  });
+
+  it('leaves live_overtime false for a program inside its own block', async () => {
+    const onAir = buildSchedule({
+      id: 43,
+      start_time: '15:00',
+      end_time: '17:00',
+    });
+
+    const [result] = await enrich([onAir], buildLiveStatus(undefined));
+
+    expect(result.program.is_live).toBe(true);
+    expect(result.program.live_overtime).toBe(false);
+  });
+});

--- a/src/youtube/optimized-schedules.service.ts
+++ b/src/youtube/optimized-schedules.service.ts
@@ -191,6 +191,20 @@ export class OptimizedSchedulesService {
     const previousDay = TimezoneUtil.previousDayOfWeek();
     const currentTime = TimezoneUtil.currentTimeInMinutes();
 
+    // Channels with something on air right now. A program that already handed
+    // the channel over to the next one must never extend into overtime, even if
+    // the cron has not cleared the entry yet (up to one 2-minute cycle of lag).
+    const channelsAiringNow = new Set<string>();
+    for (const schedule of schedules) {
+      const channelId = schedule.program.channel?.youtube_channel_id;
+      if (!channelId) continue;
+      if (
+        this.isScheduleAiring(schedule, currentDay, previousDay, currentTime)
+      ) {
+        channelsAiringNow.add(channelId);
+      }
+    }
+
     for (const schedule of schedules) {
       const enrichedSchedule = { ...schedule };
       const channelId = schedule.program.channel?.youtube_channel_id;
@@ -218,17 +232,28 @@ export class OptimizedSchedulesService {
         ? (canFetchLiveMap.get(handle) ?? true)
         : true;
 
-      const startNum = this.convertTimeToNumber(schedule.start_time);
-      const endNum = this.convertTimeToNumber(schedule.end_time);
-      const isCurrentlyLive =
-        (schedule.day_of_week === currentDay &&
-          TimezoneUtil.isTimeInRange(startNum, endNum, currentTime)) ||
-        (endNum < startNum &&
-          schedule.day_of_week === previousDay &&
-          currentTime < endNum);
+      const isCurrentlyLive = this.isScheduleAiring(
+        schedule,
+        currentDay,
+        previousDay,
+        currentTime,
+      );
 
       if (channelId && liveStatusMap.has(channelId)) {
         const liveStatus = liveStatusMap.get(channelId)!;
+
+        // The scheduled block is over but the stream this program was on is
+        // still broadcasting — keep it live so viewers can get back to it.
+        const overtimeEntry =
+          !isCurrentlyLive &&
+          !isEscalated &&
+          canFetchLive &&
+          !channelsAiringNow.has(channelId)
+            ? (liveStatus.overtime || []).find(
+                (o: { scheduleId: string }) =>
+                  String(o.scheduleId) === String(schedule.id),
+              )
+            : undefined;
 
         if (isEscalated && isCurrentlyLive) {
           enrichedSchedule.program = {
@@ -275,6 +300,17 @@ export class OptimizedSchedulesService {
             live_streams: [],
             stream_count: 0,
           };
+        } else if (overtimeEntry) {
+          enrichedSchedule.program = {
+            ...schedule.program,
+            is_live: true,
+            live_overtime: true,
+            // Always the overtime stream: the program's stored stream_url is
+            // usually a channel or playlist link, not the running broadcast.
+            stream_url: overtimeEntry.streamUrl,
+            live_streams: liveStatus.streams || [],
+            stream_count: liveStatus.streamCount || 0,
+          };
         } else {
           enrichedSchedule.program = {
             ...schedule.program,
@@ -308,10 +344,35 @@ export class OptimizedSchedulesService {
         }
       }
 
+      // Keep the field on every program so clients get a stable contract.
+      enrichedSchedule.program.live_overtime =
+        enrichedSchedule.program.live_overtime ?? false;
+
       enriched.push(enrichedSchedule);
     }
 
     return enriched;
+  }
+
+  /**
+   * Whether a schedule's own time block contains the current minute.
+   * Handles cross-midnight blocks, which land on the previous day of week.
+   */
+  private isScheduleAiring(
+    schedule: { day_of_week: string; start_time: string; end_time: string },
+    currentDay: string,
+    previousDay: string,
+    currentTime: number,
+  ): boolean {
+    const startNum = this.convertTimeToNumber(schedule.start_time);
+    const endNum = this.convertTimeToNumber(schedule.end_time);
+    return (
+      (schedule.day_of_week === currentDay &&
+        TimezoneUtil.isTimeInRange(startNum, endNum, currentTime)) ||
+      (endNum < startNum &&
+        schedule.day_of_week === previousDay &&
+        currentTime < endNum)
+    );
   }
 
   /**


### PR DESCRIPTION
## [1.40.0] - 2026-07-29

### Added

**Overtime — los programas siguen en vivo mientras la transmisión no corte**

`is_live` se decidía únicamente por la ventana horaria del schedule, así que un programa cargado de 13:00 a 15:00 pasaba a no-live a las 15:00 en punto aunque su stream siguiera al aire. El usuario que había cerrado el reproductor no tenía forma de volver: el bloque ofrecía "Ver en YouTube" en vez del vivo, y el canal desaparecía de la lista de zapping.

Había una segunda causa independiente: el cron solo consultaba canales con un programa al aire, así que terminado el bloque nadie refrescaba el caché y expiraba con su TTL alineado al bloque.

Ahora un programa se mantiene en vivo pasado su horario mientras el stream específico que tenía asignado siga transmitiendo, con tope de 180 minutos, y deja de extenderse apenas otro programa toma el canal. Los programas en overtime exponen `live_overtime: true` junto a `is_live`, y su `stream_url` apunta a la transmisión en curso en lugar del link de canal o playlist guardado en el programa.

- La validación usa `isVideoLive` (`videos.list`, 1 unidad de quota) y nunca el camino de refresh basado en `search.list`: la quota escasa es "Search Queries per day" (398/día), no "Queries per day" (50.000).
- Nuevo marcador Redis `lastLiveVideo:{handle}`, que sobrevive al TTL alineado al bloque para que siempre haya un `videoId` que validar.
- El overtime se keyea por `scheduleId` string, así que los especiales semanales de weekly overrides (ids virtuales `virtual_<overrideId>`) quedan cubiertos.
- Se notifica por SSE en las dos transiciones (inicio y fin) para que los clientes refresquen en segundos en vez de esperar hasta 5 minutos a su próximo poll.

### Fixed

- **Suite de tests que no compilaba**: cuatro spec files fallaban con `TS2345`/`TS2741` porque `seenFeatures` pasó a ser campo requerido de la entidad `User` en 1.39.0 y los mock users nunca se actualizaron. Rotura preexistente: el PR de `seen_features` se mergeó a `develop` con CI ya en rojo, así que toda branch cortada desde ahí la heredaba.

---

## Impacto en clientes

**Web** — acompaña el release 1.30.0 del frontend, que corrige el render de los bloques en overtime.

**Mobile** — no requiere nueva versión. El fix es server-side y la app actual ya lo aprovecha: badge LIVE, fondo encendido, CTA "Ver en vivo" y reproductor apuntando a la transmisión en curso funcionan sin cambios. Único defecto cosmético: el borde del bloque queda atenuado porque usa `isPast` sin excluir `isLive`.

## Deploy

Mergear a `main` dispara el deploy automático en Railway (producción).

Después del deploy conviene mirar el log del cron cada 2 minutos: `⏱️ Overtime pass: N candidates, X still on air, Y ended`, para confirmar que en producción detecta canales igual que en staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZA6G5Dh9jEJN77vsZZNiT