### PR TITLE
Release 1.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.41.0] - 2026-08-13
+
+### Added
+
+- **Verificación de propiedad del device en `POST /push/fcm/subscribe`** (modo report-only): el endpoint no tenía ningún guard, y como la fila de `devices` queda ligada a su usuario para siempre (el unsubscribe solo limpia el token), cualquiera con el `deviceId` podía volver a habilitar push para esa cuenta. Esto es lo que permitió que un mobile con la sesión ya muerta se re-suscribiera 0,7s después de desregistrarse y siguiera recibiendo notificaciones durante cinco días. Usa `OptionalJwtAuthGuard`: un device nunca reclamado sigue registrándose, pero uno con dueño no puede re-suscribirse anónimamente. Se despliega en modo report-only porque los builds de mobile anteriores a 1.0.17 no adjuntan el JWT a este endpoint; el warning registra el `X-App-Version` de cada rechazo potencial. Se activa con `PUSH_ENFORCE_DEVICE_OWNERSHIP=true` sin necesidad de redeploy.
+- **Filtro global de excepciones que loguea todos los errores HTTP** con endpoint, status, `deviceId`, `userId` y versión de app. En el ciclo de vida de Nest los guards corren *antes* que los interceptors, así que `PerformanceInterceptor` nunca veía un rechazo de `JwtAuthGuard`: los 401, el fallo más común del sistema, no dejaban ningún rastro en producción.
+
+### Fixed
+
+- **Programas ocultos manejando la detección de live**: el cron de live status leía schedules con `findAll()` sin filtrar por visibilidad, así que un programa con `is_visible=false` podía ser elegido como programa actual y su nombre comparado contra el título del video en vivo del programa visible del mismo bloque, dando 0% de match y forzando validaciones repetidas. Los ocultos también se filtraban al cálculo de TTL de bloque / `blockEndTime`, a la escalación a not-found y al enriquecimiento on-demand. Se agrega `scheduleVisibility.util` aplicado en `LiveStatusBackgroundService`, `getCurrentBlockTTL`, `getCurrentProgramEndTime`, `syncLiveStatusCacheFromStreams` y `enrichSchedulesForChannel`. El backoffice no se ve afectado: usa sus propias queries.
+- **Streams que nunca se detectaban como en vivo**: `search?eventType=live` puede devolver 0 items para un canal que está transmitiendo — el índice va atrasado respecto del inicio real de una emisión, y a veces directamente no devuelve una transmisión en curso. Eso escalaba el canal a not-found por el resto del bloque. Ahora el fallback por playlist de uploads corre siempre que search no encuentra nada y hay un programa visible al aire (no solo para `is_premiere`): `videos?part=snippet` sí las reporta como `liveBroadcastContent=live` y el camino cuesta ~4 unidades de quota contra 100 de un search.
+- **Reintento efectivo mientras hay programa al aire**: la marca `videoIdNotFound` ahora vive 2 minutos en vez de 15 cuando hay un programa visible al aire, y conserva los 15 completos cuando no hay nada programado. Acortar solo el TTL del cache de estado no alcanzaba: `liveStatusByHandle` y `videoIdNotFound` son llaves distintas, y el ciclo de background consulta la marca *antes* de fetchear, así que la entrada de cache expiraba pero el reintento se cortocircuitaba igual y el intervalo real seguía siendo de 15 minutos. La cadencia de reintento quedó desacoplada de la escalera de escalación: un intento solo se cuenta cuando pasaron los 15 minutos originales, de modo que la escalación sigue requiriendo 3 intentos y ~30 minutos y no se dispara (ni manda mail) a los pocos minutos de arrancar un programa.
+
+### Performance
+
+- **Los reintentos de not-found ya no gastan un `search`**: reintentar cada 2 minutos con un search de 100 unidades habría llevado el costo de un bloque programado que nunca sale al aire de ~310 a ~1560 unidades de quota (5x), sin ningún guard diario que lo contenga (`canFetchLive` solo mira el flag de habilitación y los feriados). Dentro de la ventana de reintento ahora se saltea el search y se usa directamente la playlist de uploads (~4 unidades: 1 de `playlistItems` + hasta 3 de `videos`), lo que deja el mismo bloque en ~350 unidades conservando 5x más oportunidades de recuperación. El camino barato es además el más certero en este escenario: durante el incidente de Luzu TV el search devolvió `totalResults: 0` para una emisión que llevaba 49 minutos en vivo y estaba en la posición 0 de la playlist de uploads. Los intentos contados siguen ejecutando el search completo, porque una transmisión larga puede quedar fuera de los 3 uploads más recientes si se publican shorts después.
+
+### Changed
+
+- **`unsubscribeFCM` ahora loguea** el `deviceId` y la cantidad de suscripciones borradas. Es el único registro del lado servidor de que un cliente cerró su sesión, y su ausencia obligaba a inferir los logouts a partir de aritmética sobre los conteos del scheduler diario.
+- Las notificaciones de streamers ya no loguean `device unknown`: se adjunta el device a la suscripción antes de enviar.
+
+
 ## [1.40.0] - 2026-07-29
 
 ### Added

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -36,6 +36,8 @@ import { BannersModule } from './banners/banners.module';
 import { ResourceMonitorService } from './services/resource-monitor.service';
 import { ConnectionPoolMonitorService } from './services/connection-pool-monitor.service';
 import { PerformanceInterceptor } from './interceptors/performance.interceptor';
+import { HttpErrorLogFilter } from './interceptors/http-error-log.filter';
+import { APP_FILTER } from '@nestjs/core';
 import { UpdatesModule } from './updates/updates.module';
 import { ConfigModule as AppConfigModule } from './config/config.module';
 
@@ -134,6 +136,11 @@ import { ConfigModule as AppConfigModule } from './config/config.module';
     {
       provide: 'APP_INTERCEPTOR',
       useClass: PerformanceInterceptor,
+    },
+    {
+      // Catches guard rejections too, which never reach the interceptor above.
+      provide: APP_FILTER,
+      useClass: HttpErrorLogFilter,
     },
   ],
 })

--- a/src/interceptors/http-error-log.filter.ts
+++ b/src/interceptors/http-error-log.filter.ts
@@ -1,0 +1,43 @@
+import { ArgumentsHost, Catch, HttpException, Logger } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+
+/**
+ * Logs every HTTP error response.
+ *
+ * PerformanceInterceptor cannot do this: in the Nest request lifecycle guards
+ * run *before* interceptors, so a JwtAuthGuard rejection short-circuits without
+ * ever reaching it — neither its "Starting request" line nor its error branch.
+ * The result was that 401s, the single most common failure in the system, left
+ * no trace whatsoever in production. Diagnosing a silent client-side logout had
+ * to be done by inferring deletions from push-subscription row counts.
+ *
+ * Exception filters run last and see everything, including guard rejections.
+ */
+@Catch()
+export class HttpErrorLogFilter extends BaseExceptionFilter {
+  private readonly logger = new Logger('HttpError');
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    if (host.getType() === 'http') {
+      const request = host.switchToHttp().getRequest();
+      const status =
+        exception instanceof HttpException ? exception.getStatus() : 500;
+      const message =
+        exception instanceof Error ? exception.message : String(exception);
+
+      // Auth failures are the ones worth surfacing loudly — they are invisible
+      // everywhere else and they are what ends user sessions.
+      const level = status === 401 || status === 403 ? 'warn' : 'error';
+      const endpoint = `${request?.method} ${request?.route?.path || request?.path || request?.url?.split('?')[0]}`;
+      const deviceId = request?.headers?.['x-device-id'] || 'unknown';
+      const appVersion = request?.headers?.['x-app-version'] || 'unknown';
+      const userId = request?.user?.id ?? 'anonymous';
+
+      this.logger[level](
+        `🔒 ${status} ${endpoint} — deviceId=${deviceId}, userId=${userId}, appVersion=${appVersion}, reason="${message}"`,
+      );
+    }
+
+    super.catch(exception, host);
+  }
+}

--- a/src/push/push.controller.ts
+++ b/src/push/push.controller.ts
@@ -1,7 +1,16 @@
-import { Controller, Post, Body, Get, Logger } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Logger,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { PushService } from './push.service';
 import { CreatePushSubscriptionDto } from './dto/create-push-subscription.dto';
 import { ScheduleNotificationDto } from './dto/schedule-notification.dto';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 
 @Controller('push')
 export class PushController {
@@ -18,8 +27,18 @@ export class PushController {
     return this.svc.create(dto);
   }
 
+  /**
+   * Optional auth rather than a hard guard: the caller may legitimately be
+   * anonymous when the device has never been claimed by a user. What must not
+   * happen is an unauthenticated call re-subscribing a device that *is* owned —
+   * that is how a logged-out app resurrected its own push subscription moments
+   * after logout and kept delivering notifications for days. Ownership is
+   * enforced in the service.
+   */
   @Post('fcm/subscribe')
+  @UseGuards(OptionalJwtAuthGuard)
   subscribeFCM(
+    @Request() req: any,
     @Body()
     body: {
       deviceId: string;
@@ -27,14 +46,22 @@ export class PushController {
       platform: 'ios' | 'android' | 'web';
     },
   ) {
+    const appVersion = req.headers?.['x-app-version'] || 'unknown';
     this.logger.log(
-      `📱 FCM subscribe request: deviceId=${body.deviceId}, platform=${body.platform}, tokenPrefix=${body.fcmToken?.substring(0, 20)}...`,
+      `📱 FCM subscribe request: deviceId=${body.deviceId}, platform=${body.platform}, userId=${req.user?.id ?? 'anonymous'}, appVersion=${appVersion}, tokenPrefix=${body.fcmToken?.substring(0, 20)}...`,
     );
-    return this.svc.createFCM(body.deviceId, body.fcmToken, body.platform);
+    return this.svc.createFCM(
+      body.deviceId,
+      body.fcmToken,
+      body.platform,
+      req.user?.id ?? null,
+      appVersion,
+    );
   }
 
   @Post('fcm/unsubscribe')
   unsubscribeFCM(@Body() body: { deviceId: string }) {
+    this.logger.log(`📱 FCM unsubscribe request: deviceId=${body.deviceId}`);
     return this.svc.unsubscribeFCM(body.deviceId);
   }
 

--- a/src/push/push.service.spec.ts
+++ b/src/push/push.service.spec.ts
@@ -266,4 +266,107 @@ describe('PushService', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('createFCM device ownership', () => {
+    const ownedDevice = {
+      ...mockDevice,
+      platform: 'android',
+      fcmToken: null,
+      user: { id: 1 },
+    } as unknown as Device;
+
+    const originalEnforce = process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP;
+
+    const allowSubscriptionCreation = () => {
+      const saveable = { ...ownedDevice } as Device;
+      mockDeviceRepository.findOne.mockResolvedValue(saveable);
+      (mockDeviceRepository as any).save = jest.fn().mockResolvedValue(saveable);
+      mockPushSubscriptionRepository.findOne.mockResolvedValue(null);
+      mockPushSubscriptionRepository.create.mockReturnValue(
+        mockPushSubscription,
+      );
+      mockPushSubscriptionRepository.save.mockResolvedValue(
+        mockPushSubscription,
+      );
+    };
+
+    afterEach(() => {
+      if (originalEnforce === undefined) {
+        delete process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP;
+      } else {
+        process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP = originalEnforce;
+      }
+    });
+
+    describe('when enforcing', () => {
+      beforeEach(() => {
+        process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP = 'true';
+      });
+
+      it('rejects an anonymous subscribe for a device owned by a user', async () => {
+        mockDeviceRepository.findOne.mockResolvedValue(ownedDevice);
+
+        await expect(
+          service.createFCM('test-device-id', 'fcm-token', 'android', null),
+        ).rejects.toThrow(
+          'Device belongs to another user or no session was provided',
+        );
+
+        expect(mockPushSubscriptionRepository.save).not.toHaveBeenCalled();
+      });
+
+      it('rejects a subscribe from a different user', async () => {
+        mockDeviceRepository.findOne.mockResolvedValue(ownedDevice);
+
+        await expect(
+          service.createFCM('test-device-id', 'fcm-token', 'android', 2),
+        ).rejects.toThrow(
+          'Device belongs to another user or no session was provided',
+        );
+
+        expect(mockPushSubscriptionRepository.save).not.toHaveBeenCalled();
+      });
+
+      it('allows the owning user to subscribe', async () => {
+        allowSubscriptionCreation();
+
+        await expect(
+          service.createFCM('test-device-id', 'fcm-token', 'android', 1),
+        ).resolves.toEqual(mockPushSubscription);
+
+        expect(mockPushSubscriptionRepository.save).toHaveBeenCalled();
+      });
+    });
+
+    describe('report-only (default)', () => {
+      beforeEach(() => {
+        delete process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP;
+      });
+
+      it('warns with the app version but still subscribes on a mismatch', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        allowSubscriptionCreation();
+
+        await expect(
+          service.createFCM(
+            'test-device-id',
+            'fcm-token',
+            'android',
+            null,
+            '1.0.15',
+          ),
+        ).resolves.toEqual(mockPushSubscription);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('appVersion=1.0.15'),
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('enforcing=false'),
+        );
+        expect(mockPushSubscriptionRepository.save).toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+      });
+    });
+  });
 });

--- a/src/push/push.service.ts
+++ b/src/push/push.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import * as webPush from 'web-push';
@@ -162,9 +162,12 @@ export class PushService {
     deviceId: string,
     fcmToken: string,
     platform: 'ios' | 'android' | 'web',
+    requesterUserId: number | string | null = null,
+    /** Only used to attribute report-only ownership warnings to a build. */
+    appVersion?: string,
   ) {
     console.log(
-      `📱 [PushService] createFCM called: deviceId=${deviceId}, platform=${platform}, tokenPrefix=${fcmToken?.substring(0, 20)}...`,
+      `📱 [PushService] createFCM called: deviceId=${deviceId}, platform=${platform}, requesterUserId=${requesterUserId ?? 'anonymous'}, tokenPrefix=${fcmToken?.substring(0, 20)}...`,
     );
 
     if (!fcmToken || fcmToken.trim() === '') {
@@ -174,6 +177,7 @@ export class PushService {
 
     const device = await this.deviceRepository.findOne({
       where: { deviceId },
+      relations: ['user'],
     });
 
     if (!device) {
@@ -181,6 +185,34 @@ export class PushService {
         `❌ [PushService] Device not found for deviceId=${deviceId}`,
       );
       throw new Error('Device not found');
+    }
+
+    // A device row stays bound to its user forever — unsubscribing only clears
+    // the token. So without this check, anyone holding the deviceId (including
+    // the app itself after its session died) can re-arm push delivery for that
+    // user's account.
+    //
+    // Rolled out in report-only mode: mobile builds before 1.0.17 do not attach
+    // the JWT to this endpoint (the request interceptor gained that in 3b613b3),
+    // so enforcing immediately would silently stop push registration for anyone
+    // still on an older build. The warning below records the app version of
+    // every would-be rejection; once the logs confirm no old client is hitting
+    // it, set PUSH_ENFORCE_DEVICE_OWNERSHIP=true to start rejecting.
+    if (
+      device.user &&
+      (requesterUserId === null ||
+        String(device.user.id) !== String(requesterUserId))
+    ) {
+      const enforcing =
+        process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP === 'true';
+      console.warn(
+        `🚫 [PushService] FCM subscribe ownership mismatch: deviceId=${deviceId}, ownedByUser=${device.user.id}, requester=${requesterUserId ?? 'anonymous'}, appVersion=${appVersion ?? 'unknown'}, enforcing=${enforcing}`,
+      );
+      if (enforcing) {
+        throw new UnauthorizedException(
+          'Device belongs to another user or no session was provided',
+        );
+      }
     }
 
     console.log(
@@ -226,13 +258,25 @@ export class PushService {
 
   async unsubscribeFCM(deviceId: string) {
     const device = await this.deviceRepository.findOne({ where: { deviceId } });
-    if (!device) return;
+    if (!device) {
+      console.warn(
+        `⚠️ [PushService] unsubscribeFCM: device not found for deviceId=${deviceId}`,
+      );
+      return;
+    }
 
     // Remove subscriptions for this device that are FCM (null keys)
-    await this.repo.delete({ device: { id: device.id } }); // Delete all pushes for this device for safety
+    const result = await this.repo.delete({ device: { id: device.id } }); // Delete all pushes for this device for safety
 
     device.fcmToken = null;
     await this.deviceRepository.save(device);
+
+    // Logged because this is the only record that a client tore its session
+    // down: the 401 that triggers it never reaches an interceptor, so without
+    // this line a logout leaves no server-side trace at all.
+    console.log(
+      `✅ [PushService] unsubscribeFCM: deviceId=${deviceId}, deleted ${result.affected ?? 0} push subscription(s), fcmToken cleared`,
+    );
     return { success: true };
   }
 

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -26,6 +26,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { ConfigService } from '../config/config.service';
 import { NotifyAndRevalidateUtil } from '../utils/notify-and-revalidate.util';
 import { TimezoneUtil } from '../utils/timezone.util';
+import { filterVisibleSchedules } from '../utils/scheduleVisibility.util';
 
 const FRONTEND_URL =
   process.env.FRONTEND_URL || 'https://staging.laguiadelstreaming.com';
@@ -461,8 +462,10 @@ export class SchedulesService {
     }
 
     // Find live schedules for this channel (only if liveStatus is enabled)
+    // Hidden programs (is_visible=false) are excluded: they must not trigger YouTube fetches
+    // nor claim a live stream via title matching
     const liveSchedules = liveStatus
-      ? schedules.filter((schedule) => {
+      ? filterVisibleSchedules(schedules).filter((schedule) => {
           const startNum = this.convertTimeToNumber(schedule.start_time);
           const endNum = this.convertTimeToNumber(schedule.end_time);
           return (

--- a/src/streamers/streamer-subscription.service.ts
+++ b/src/streamers/streamer-subscription.service.ts
@@ -185,6 +185,10 @@ export class StreamerSubscriptionService {
           if (device.pushSubscriptions && device.pushSubscriptions.length > 0) {
             for (const pushSub of device.pushSubscriptions) {
               try {
+                // The device relation is not loaded on the inverse side here,
+                // which is why sendNotification used to log "device unknown"
+                // for every streamer push. Attach it so sends are traceable.
+                pushSub.device = pushSub.device ?? device;
                 await this.pushService.sendNotification(pushSub, {
                   title,
                   options: {

--- a/src/utils/getBlockTTL.util.ts
+++ b/src/utils/getBlockTTL.util.ts
@@ -5,6 +5,7 @@ import * as timezone from 'dayjs/plugin/timezone';
 import { convertTimeToMinutes } from './convertTimeToMinutes.util';
 import { SentryService } from '../sentry/sentry.service';
 import { TimezoneUtil } from './timezone.util';
+import { isScheduleVisible } from './scheduleVisibility.util';
 
 // Simple in-memory cache to prevent duplicate alerts for the same channel within a short time window
 const alertCache = new Map<string, number>();
@@ -26,9 +27,14 @@ export async function getCurrentBlockTTL(
   const now = TimezoneUtil.now();
   const currentTimeInMinutes = TimezoneUtil.currentTimeInMinutes();
 
-  // Filtrar sólo del canal
+  // Filtrar sólo del canal, ignorando programas/canales ocultos (is_visible=false):
+  // no deben definir los límites del bloque ni el TTL del cache de live status
   const channelSched = schedules
-    .filter((s) => s.program.channel?.youtube_channel_id === channelId)
+    .filter(
+      (s) =>
+        s.program.channel?.youtube_channel_id === channelId &&
+        isScheduleVisible(s),
+    )
     .map((s) => ({
       start: convertTimeToMinutes(s.start_time),
       end: convertTimeToMinutes(s.end_time),

--- a/src/utils/scheduleVisibility.util.ts
+++ b/src/utils/scheduleVisibility.util.ts
@@ -1,0 +1,30 @@
+/**
+ * Visibility helpers for schedules.
+ *
+ * A program (or channel) with `is_visible = false` is a backoffice-only record: it must never
+ * influence live detection, title matching, block TTL calculation or not-found escalation.
+ * Only the backoffice reads them, and it does so with its own (raw) queries.
+ *
+ * `undefined` is treated as visible to match the DB default (`true`) and to stay safe when a
+ * query selects a subset of columns.
+ */
+
+interface ScheduleLike {
+  program?: {
+    is_visible?: boolean;
+    channel?: { is_visible?: boolean } | null;
+  } | null;
+}
+
+export function isScheduleVisible(schedule: ScheduleLike): boolean {
+  return (
+    schedule?.program?.is_visible !== false &&
+    schedule?.program?.channel?.is_visible !== false
+  );
+}
+
+export function filterVisibleSchedules<T extends ScheduleLike>(
+  schedules: T[],
+): T[] {
+  return (schedules || []).filter(isScheduleVisible);
+}

--- a/src/youtube/live-status-background.service.ts
+++ b/src/youtube/live-status-background.service.ts
@@ -11,6 +11,7 @@ import { TimezoneUtil } from '../utils/timezone.util';
 import { Channel } from '../channels/channels.entity';
 import { getCurrentBlockTTL } from '../utils/getBlockTTL.util';
 import { SimilarityUtil } from '../utils/similarity.util';
+import { filterVisibleSchedules } from '../utils/scheduleVisibility.util';
 
 interface LiveStream {
   videoId: string;
@@ -67,6 +68,13 @@ export class LiveStatusBackgroundService {
   private readonly logger = new Logger(LiveStatusBackgroundService.name);
   private readonly CACHE_PREFIX = 'liveStatusByHandle:'; // Migration complete
   private readonly CACHE_TTL = 5 * 60; // 5 minutes default TTL
+  /**
+   * TTL used when a program is on-air but no live stream was found.
+   * Must stay short so the next background run retries instead of freezing the channel as
+   * "not live" for the whole program block (a stream that starts a few minutes late, or that
+   * YouTube's search index hasn't picked up yet, would otherwise never be detected).
+   */
+  private readonly NOT_FOUND_RETRY_TTL = 2 * 60; // 2 minutes
 
   // ── Overtime: programs still on air after their scheduled block ended ──
   private readonly LAST_LIVE_PREFIX = 'lastLiveVideo:';
@@ -124,18 +132,24 @@ export class LiveStatusBackgroundService {
 
       // Get schedules with weekly overrides applied (includes virtual/special programs)
       // This is crucial for detecting special programs from weekly overrides
-      const todaySchedules = await this.schedulesService.findAll({
-        dayOfWeek: currentDay,
-        liveStatus: false, // Don't need live status, just schedule data
-        applyOverrides: true, // ✅ CRITICAL: Apply weekly overrides to include special programs
-      });
+      // ✅ Hidden programs/channels (is_visible=false) are backoffice-only and must not take
+      // part in live detection or title matching
+      const todaySchedules = filterVisibleSchedules(
+        await this.schedulesService.findAll({
+          dayOfWeek: currentDay,
+          liveStatus: false, // Don't need live status, just schedule data
+          applyOverrides: true, // ✅ CRITICAL: Apply weekly overrides to include special programs
+        }),
+      );
 
       // Also fetch previous day's schedules to catch cross-midnight programs still running
-      const previousDaySchedules = await this.schedulesService.findAll({
-        dayOfWeek: previousDay,
-        liveStatus: false,
-        applyOverrides: true,
-      });
+      const previousDaySchedules = filterVisibleSchedules(
+        await this.schedulesService.findAll({
+          dayOfWeek: previousDay,
+          liveStatus: false,
+          applyOverrides: true,
+        }),
+      );
       const crossMidnightSchedules = previousDaySchedules.filter((s) => {
         const startNum = this.convertTimeToNumber(s.start_time);
         const endNum = this.convertTimeToNumber(s.end_time);
@@ -577,18 +591,24 @@ export class LiveStatusBackgroundService {
       const currentTime = TimezoneUtil.currentTimeInMinutes();
 
       // Get schedules with weekly overrides applied (includes virtual/special programs)
-      const todayAllSchedules = await this.schedulesService.findAll({
-        dayOfWeek: currentDay,
-        liveStatus: false,
-        applyOverrides: true, // ✅ Include special programs from weekly overrides
-      });
+      // Hidden programs/channels are excluded: they must not drive live detection, block TTL
+      // or title matching (see scheduleVisibility.util)
+      const todayAllSchedules = filterVisibleSchedules(
+        await this.schedulesService.findAll({
+          dayOfWeek: currentDay,
+          liveStatus: false,
+          applyOverrides: true, // ✅ Include special programs from weekly overrides
+        }),
+      );
 
       // Also include previous day's cross-midnight schedules still in progress
-      const previousDayAllSchedules = await this.schedulesService.findAll({
-        dayOfWeek: previousDay,
-        liveStatus: false,
-        applyOverrides: true,
-      });
+      const previousDayAllSchedules = filterVisibleSchedules(
+        await this.schedulesService.findAll({
+          dayOfWeek: previousDay,
+          liveStatus: false,
+          applyOverrides: true,
+        }),
+      );
       const crossMidnightAllSchedules = previousDayAllSchedules.filter((s) => {
         const startNum = this.convertTimeToNumber(s.start_time);
         const endNum = this.convertTimeToNumber(s.end_time);
@@ -873,13 +893,23 @@ export class LiveStatusBackgroundService {
         liveStreams,
       );
 
+      const foundLiveStreams =
+        liveStreams !== null &&
+        liveStreams !== '__SKIPPED__' &&
+        liveStreams.streams.length > 0;
+
+      // A program is on-air (liveSchedules.length > 0) but we found no stream: keep the negative
+      // result short-lived so the next background run retries. Caching it for the whole block
+      // (ttl) would freeze the channel as "not live" until the program ends, even if the stream
+      // shows up a few minutes later.
+      const cacheTTL = foundLiveStreams
+        ? ttl
+        : Math.min(ttl, this.NOT_FOUND_RETRY_TTL);
+
       const cacheData: LiveStatusCache = {
         channelId,
         handle,
-        isLive:
-          liveStreams !== null &&
-          liveStreams !== '__SKIPPED__' &&
-          liveStreams.streams.length > 0,
+        isLive: foundLiveStreams,
         streamUrl:
           liveStreams &&
           liveStreams !== '__SKIPPED__' &&
@@ -891,7 +921,7 @@ export class LiveStatusBackgroundService {
             ? liveStreams.primaryVideoId
             : null,
         lastUpdated: Date.now(),
-        ttl,
+        ttl: cacheTTL,
         blockEndTime,
         validationCooldown: Date.now() + 30 * 60 * 1000, // Can validate again in 30 minutes
         lastValidation: Date.now(),

--- a/src/youtube/live-status-background.service.visibility.spec.ts
+++ b/src/youtube/live-status-background.service.visibility.spec.ts
@@ -1,0 +1,229 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LiveStatusBackgroundService } from './live-status-background.service';
+import { YoutubeLiveService } from './youtube-live.service';
+import { SchedulesService } from '../schedules/schedules.service';
+import { RedisService } from '../redis/redis.service';
+import { ConfigService } from '../config/config.service';
+import { SentryService } from '../sentry/sentry.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Channel } from '../channels/channels.entity';
+import { TimezoneUtil } from '../utils/timezone.util';
+import * as dayjs from 'dayjs';
+
+const CHANNEL_ID = 'UCvCTWHCbBC0b9UIeLeNs8ug';
+const HANDLE = 'VorterixOficial';
+
+/**
+ * Regression tests for the Vorterix incident (2026-08-13):
+ * - A hidden program ("Dejá que entre el sol", is_visible=false, 10:00-13:00) was compared
+ *   against the live video title of the visible program ("Y QUÉ?", same slot), producing a
+ *   0% match and forcing needless validations.
+ * - When no live stream was found while a program was on-air, the negative result was cached
+ *   for the whole block, freezing the channel as not-live until the program ended.
+ */
+describe('LiveStatusBackgroundService visibility + negative cache', () => {
+  let service: LiveStatusBackgroundService;
+  let schedulesService: { findAll: jest.Mock };
+  let redisService: {
+    get: jest.Mock;
+    set: jest.Mock;
+    del: jest.Mock;
+    setNX: jest.Mock;
+  };
+  let youtubeLiveService: {
+    isVideoLive: jest.Mock;
+    getLiveStreamsMain: jest.Mock;
+  };
+  let configService: {
+    canFetchLive: jest.Mock;
+    isTitleMatchDisabled: jest.Mock;
+  };
+
+  /**
+   * Freezes both the "minutes since midnight" helper and `now()` so block TTL calculations
+   * (which diff `todayAtTime(blockEnd)` against `now()`) stay consistent with the simulated clock.
+   */
+  const setSimulatedTime = (minutes: number) => {
+    jest.spyOn(TimezoneUtil, 'currentTimeInMinutes').mockReturnValue(minutes);
+    jest
+      .spyOn(TimezoneUtil, 'now')
+      .mockImplementation(
+        () => dayjs().startOf('day').add(minutes, 'minute') as any,
+      );
+  };
+
+  const makeSchedule = (
+    programName: string,
+    start: string,
+    end: string,
+    isVisible = true,
+  ) => ({
+    day_of_week: 'thursday',
+    start_time: start,
+    end_time: end,
+    program: {
+      name: programName,
+      is_visible: isVisible,
+      channel: {
+        handle: HANDLE,
+        youtube_channel_id: CHANNEL_ID,
+        is_visible: true,
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    schedulesService = { findAll: jest.fn().mockResolvedValue([]) };
+    redisService = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(undefined),
+      del: jest.fn().mockResolvedValue(undefined),
+      setNX: jest.fn().mockResolvedValue(true),
+    };
+    youtubeLiveService = {
+      isVideoLive: jest.fn().mockResolvedValue(true),
+      getLiveStreamsMain: jest.fn().mockResolvedValue(null),
+    };
+    configService = {
+      canFetchLive: jest.fn().mockResolvedValue(true),
+      isTitleMatchDisabled: jest.fn().mockResolvedValue(false),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LiveStatusBackgroundService,
+        { provide: YoutubeLiveService, useValue: youtubeLiveService },
+        { provide: SchedulesService, useValue: schedulesService },
+        { provide: RedisService, useValue: redisService },
+        { provide: ConfigService, useValue: configService },
+        {
+          provide: SentryService,
+          useValue: {
+            captureException: jest.fn(),
+            captureMessage: jest.fn(),
+            setTag: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(Channel),
+          useValue: { find: jest.fn(), findOne: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get(LiveStatusBackgroundService);
+
+    jest.spyOn(TimezoneUtil, 'currentDayOfWeek').mockReturnValue('thursday');
+    jest.spyOn(TimezoneUtil, 'previousDayOfWeek').mockReturnValue('wednesday');
+    setSimulatedTime(12 * 60); // 12:00
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('hidden programs', () => {
+    it('matches the live video title against the visible program, not the hidden one', async () => {
+      // Both programs cover 10:00-13:00; the hidden one is listed first (as the DB returned it)
+      schedulesService.findAll.mockResolvedValue([
+        makeSchedule('Dejá que entre el sol', '10:00', '13:00', false),
+        makeSchedule('Y QUÉ?', '10:00', '13:00', true),
+      ]);
+
+      redisService.get.mockImplementation(async (key: string) => {
+        if (key === `liveStatusByHandle:${HANDLE}`) {
+          return {
+            channelId: CHANNEL_ID,
+            handle: HANDLE,
+            isLive: true,
+            streamUrl: 'https://www.youtube.com/embed/T555fdNUTZ4?autoplay=1',
+            videoId: 'T555fdNUTZ4',
+            lastUpdated: Date.now(),
+            ttl: 3600,
+            blockEndTime: 13 * 60,
+            validationCooldown: Date.now() + 30 * 60 * 1000,
+            lastValidation: Date.now(), // fresh: no age-based validation
+            streams: [
+              {
+                videoId: 'T555fdNUTZ4',
+                title:
+                  '🔴 Y QUÉ? con Guille Aquino, Damián Kuc, Navaja Crimen y Anacleta | VORTERIX EN VIVO',
+              },
+            ],
+            streamCount: 1,
+          };
+        }
+        return null;
+      });
+
+      const result = await (service as any).updateChannelLiveStatus(CHANNEL_ID);
+
+      // Title matches the visible program → cached video kept, no extra validation, no fetch
+      expect(result.videoId).toBe('T555fdNUTZ4');
+      expect(youtubeLiveService.isVideoLive).not.toHaveBeenCalled();
+      expect(youtubeLiveService.getLiveStreamsMain).not.toHaveBeenCalled();
+    });
+
+    it('does not mark a channel live when only a hidden program is on-air', async () => {
+      schedulesService.findAll.mockResolvedValue([
+        makeSchedule('Dejá que entre el sol', '10:00', '13:00', false),
+      ]);
+
+      const result = await (service as any).updateChannelLiveStatus(CHANNEL_ID);
+
+      // No visible schedules at all for this channel → nothing to update
+      expect(result).toBeNull();
+      expect(youtubeLiveService.getLiveStreamsMain).not.toHaveBeenCalled();
+    });
+
+    it('excludes channels whose only on-air program is hidden from the cron', async () => {
+      schedulesService.findAll.mockResolvedValue([
+        makeSchedule('Dejá que entre el sol', '10:00', '13:00', false),
+      ]);
+
+      await service.updateLiveStatusBackground();
+
+      expect(redisService.get).not.toHaveBeenCalledWith(
+        `liveStatusByHandle:${HANDLE}`,
+      );
+    });
+  });
+
+  describe('negative cache TTL', () => {
+    it('caches a not-found result with a short TTL while the program is on-air', async () => {
+      schedulesService.findAll.mockResolvedValue([
+        makeSchedule('No se pudo', '13:00', '15:00'),
+      ]);
+      setSimulatedTime(13 * 60 + 2); // 13:02, block ends at 15:00
+
+      youtubeLiveService.getLiveStreamsMain.mockResolvedValue(null);
+
+      const result = await (service as any).updateChannelLiveStatus(CHANNEL_ID);
+
+      expect(result.isLive).toBe(false);
+      // 2 minutes, not the ~2 hours left in the block
+      expect(result.ttl).toBe(2 * 60);
+      expect(redisService.set).toHaveBeenCalledWith(
+        `liveStatusByHandle:${HANDLE}`,
+        expect.objectContaining({ isLive: false, ttl: 2 * 60 }),
+        2 * 60,
+      );
+    });
+
+    it('keeps the full block TTL when a live stream is found', async () => {
+      schedulesService.findAll.mockResolvedValue([
+        makeSchedule('No se pudo', '13:00', '15:00'),
+      ]);
+      setSimulatedTime(13 * 60 + 2);
+
+      youtubeLiveService.getLiveStreamsMain.mockResolvedValue({
+        streams: [{ videoId: 'abc123', title: '#NOSEPUDO' }],
+        primaryVideoId: 'abc123',
+        streamCount: 1,
+      });
+
+      const result = await (service as any).updateChannelLiveStatus(CHANNEL_ID);
+
+      expect(result.isLive).toBe(true);
+      expect(result.ttl).toBeGreaterThan(2 * 60);
+    });
+  });
+});

--- a/src/youtube/youtube-live.service.not-found-retry.spec.ts
+++ b/src/youtube/youtube-live.service.not-found-retry.spec.ts
@@ -1,0 +1,265 @@
+import { YoutubeLiveService } from './youtube-live.service';
+import { ConfigService } from '../config/config.service';
+import { SchedulesService } from '../schedules/schedules.service';
+import { RedisService } from '../redis/redis.service';
+import { SentryService } from '../sentry/sentry.service';
+import { TimezoneUtil } from '../utils/timezone.util';
+
+const CHANNEL_ID = 'UCTHaNTsP7hsVgBxARZTuajw';
+const HANDLE = 'luzutv';
+const NOT_FOUND_KEY = `videoIdNotFound:${HANDLE}`;
+const TRACKING_KEY = `notFoundAttempts:${HANDLE}`;
+
+const ON_AIR_RETRY_TTL = 120;
+const DEFAULT_TTL = 900;
+
+/**
+ * Regression tests for the Luzu TV incident (2026-08-14): "Nadie Dice Nada" (10:00-12:30) was
+ * escalated to not-found at 11:00 and emailed about, while the program was demonstrably live —
+ * search?eventType=live simply returned 0 results for a channel that was streaming.
+ *
+ * Two properties have to hold together, and they pull in opposite directions:
+ *   1. While a visible program is on-air the not-found mark must be short, so the background
+ *      run actually re-queries YouTube instead of being skipped by the not-found gate.
+ *   2. Those fast retries must NOT advance the escalation ladder, or three of them would
+ *      escalate (and email) within minutes of a program starting.
+ */
+describe('YoutubeLiveService not-found retry cadence', () => {
+  let service: YoutubeLiveService;
+  let redisService: jest.Mocked<RedisService>;
+  let schedulesService: jest.Mocked<SchedulesService>;
+  let channelsRepository: { findOne: jest.Mock };
+  let emailService: { sendEmail: jest.Mock };
+
+  /** 11:00, inside the 10:00-12:30 block. */
+  const NOW_MINUTES = 11 * 60;
+
+  const makeSchedule = (overrides: Record<string, any> = {}) => ({
+    start_time: '10:00:00',
+    end_time: '12:30:00',
+    program: {
+      name: 'Nadie Dice Nada',
+      is_visible: true,
+      channel: { youtube_channel_id: CHANNEL_ID },
+      ...(overrides.program ?? {}),
+    },
+    ...overrides,
+  });
+
+  /** Extracts the TTL the not-found mark was written with, or undefined if never written. */
+  const notFoundTTL = (): number | undefined =>
+    redisService.set.mock.calls.find((call) => call[0] === NOT_FOUND_KEY)?.[2];
+
+  /** Extracts the tracking object last persisted, or undefined if never written. */
+  const persistedTracking = (): any =>
+    redisService.set.mock.calls
+      .filter((call) => call[0] === TRACKING_KEY)
+      .map((call) => call[1])
+      .pop();
+
+  const escalate = () =>
+    (service as any).handleNotFoundEscalationMain(
+      CHANNEL_ID,
+      HANDLE,
+      NOT_FOUND_KEY,
+    );
+
+  beforeEach(() => {
+    redisService = {
+      get: jest.fn().mockResolvedValue(null),
+      mget: jest.fn().mockResolvedValue([]),
+      set: jest.fn(),
+      del: jest.fn(),
+      incr: jest.fn(),
+      setNX: jest.fn().mockResolvedValue(true),
+    } as any;
+    schedulesService = {
+      findAll: jest.fn().mockResolvedValue([makeSchedule()]),
+      findByDay: jest.fn(),
+      enrichSchedules: jest.fn((s) => Promise.resolve(s)),
+    } as any;
+    channelsRepository = {
+      findOne: jest.fn().mockResolvedValue({ is_visible: true }),
+    };
+    emailService = { sendEmail: jest.fn() };
+
+    jest.spyOn(TimezoneUtil, 'currentDayOfWeek').mockReturnValue('friday');
+    jest
+      .spyOn(TimezoneUtil, 'currentTimeInMinutes')
+      .mockReturnValue(NOW_MINUTES);
+
+    service = new YoutubeLiveService(
+      { canFetchLive: jest.fn().mockResolvedValue(true) } as any,
+      schedulesService,
+      redisService,
+      {
+        captureMessage: jest.fn(),
+        captureException: jest.fn(),
+        setTag: jest.fn(),
+        addBreadcrumb: jest.fn(),
+      } as any as jest.Mocked<SentryService>,
+      emailService as any,
+      channelsRepository as any,
+    );
+
+    // The ladder is what is under test; the program-end lookup is incidental.
+    jest
+      .spyOn(service as any, 'getCurrentProgramEndTime')
+      .mockResolvedValue(Date.now() + 90 * 60 * 1000);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('first attempt', () => {
+    it('marks not-found briefly while a visible program is on-air', async () => {
+      await escalate();
+
+      expect(notFoundTTL()).toBe(ON_AIR_RETRY_TTL);
+      expect(persistedTracking()).toMatchObject({
+        attempts: 1,
+        escalated: false,
+      });
+    });
+
+    it('keeps the long mark when nothing is on-air', async () => {
+      // Program already finished — there is nothing to retry for.
+      jest
+        .spyOn(TimezoneUtil, 'currentTimeInMinutes')
+        .mockReturnValue(13 * 60);
+
+      await escalate();
+
+      expect(notFoundTTL()).toBe(DEFAULT_TTL);
+    });
+  });
+
+  describe('fast retries', () => {
+    it('does not count an attempt before the 15 minute window elapses', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 1,
+        firstAttempt: Date.now() - 4 * 60 * 1000,
+        lastAttempt: Date.now() - 4 * 60 * 1000,
+        escalated: false,
+      } as any);
+
+      await escalate();
+
+      expect(notFoundTTL()).toBe(ON_AIR_RETRY_TTL);
+      // Tracking must be left alone: no increment, no refreshed lastAttempt.
+      expect(persistedTracking()).toBeUndefined();
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('counts an attempt once the window has elapsed', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 1,
+        firstAttempt: Date.now() - 16 * 60 * 1000,
+        lastAttempt: Date.now() - 16 * 60 * 1000,
+        escalated: false,
+      } as any);
+
+      await escalate();
+
+      expect(persistedTracking()).toMatchObject({ attempts: 2 });
+      expect(notFoundTTL()).toBe(ON_AIR_RETRY_TTL);
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('quota: which runs are allowed to spend a search', () => {
+    const isUploadsOnlyRetry = (
+      programName: string | null = 'Nadie Dice Nada',
+      cronType: 'main' | 'back-to-back-fix' | 'manual' = 'main',
+    ) =>
+      (service as any).isUploadsOnlyRetry(HANDLE, programName, cronType);
+
+    it('skips the search on an uncounted retry', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 1,
+        firstAttempt: Date.now() - 4 * 60 * 1000,
+        lastAttempt: Date.now() - 4 * 60 * 1000,
+        escalated: false,
+      } as any);
+
+      await expect(isUploadsOnlyRetry()).resolves.toBe(true);
+    });
+
+    it('spends a search on a counted attempt', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 1,
+        firstAttempt: Date.now() - 16 * 60 * 1000,
+        lastAttempt: Date.now() - 16 * 60 * 1000,
+        escalated: false,
+      } as any);
+
+      await expect(isUploadsOnlyRetry()).resolves.toBe(false);
+    });
+
+    it('spends a search on the first look, with no tracking yet', async () => {
+      redisService.get.mockResolvedValue(null);
+
+      await expect(isUploadsOnlyRetry()).resolves.toBe(false);
+    });
+
+    it('does not apply once escalated', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 3,
+        firstAttempt: Date.now() - 40 * 60 * 1000,
+        lastAttempt: Date.now() - 60 * 1000,
+        escalated: true,
+      } as any);
+
+      await expect(isUploadsOnlyRetry()).resolves.toBe(false);
+    });
+
+    it('does not apply when no visible program is on-air', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 1,
+        firstAttempt: Date.now() - 60 * 1000,
+        lastAttempt: Date.now() - 60 * 1000,
+        escalated: false,
+      } as any);
+
+      // Without a program name the uploads fallback would not run either, so skipping
+      // the search would leave nothing to detect with.
+      await expect(isUploadsOnlyRetry(null)).resolves.toBe(false);
+    });
+
+    it('leaves the back-to-back cron on its own ladder', async () => {
+      redisService.get.mockResolvedValue({
+        attempts: 1,
+        firstAttempt: Date.now() - 60 * 1000,
+        lastAttempt: Date.now() - 60 * 1000,
+        escalated: false,
+      } as any);
+
+      await expect(
+        isUploadsOnlyRetry('Nadie Dice Nada', 'back-to-back-fix'),
+      ).resolves.toBe(false);
+    });
+
+    it('falls back to the search when tracking cannot be read', async () => {
+      redisService.get.mockRejectedValue(new Error('redis down'));
+
+      await expect(isUploadsOnlyRetry()).resolves.toBe(false);
+    });
+  });
+
+  it('still escalates on the third counted attempt', async () => {
+    redisService.get.mockResolvedValue({
+      attempts: 2,
+      firstAttempt: Date.now() - 32 * 60 * 1000,
+      lastAttempt: Date.now() - 16 * 60 * 1000,
+      escalated: false,
+    } as any);
+
+    await escalate();
+
+    expect(persistedTracking()).toMatchObject({
+      attempts: 3,
+      escalated: true,
+    });
+    // Marked until program end, far beyond the retry TTL.
+    expect(notFoundTTL()).toBeGreaterThan(ON_AIR_RETRY_TTL);
+  });
+});

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -26,6 +26,7 @@ import {
   extractLiveStreamsResult,
 } from './interfaces/live-status-cache.interface';
 import { SimilarityUtil } from '../utils/similarity.util';
+import { filterVisibleSchedules } from '../utils/scheduleVisibility.util';
 
 const HolidaysClass = (DateHolidays as any).default ?? DateHolidays;
 
@@ -47,6 +48,23 @@ export class YoutubeLiveService {
   private readonly inFlightFetches = new Set<string>(); // Track in-flight YouTube API requests to prevent duplicates
   private readonly MAX_IN_FLIGHT = 50; // Safety cap — auto-clear if set grows beyond this
   private readonly YOUTUBE_API_TIMEOUT_MS = 10_000;
+
+  /** Not-found mark lifetime when nothing is on-air — the channel is simply offline. */
+  private readonly NOT_FOUND_TTL = 900; // 15 minutes
+  /**
+   * Shorter mark used while a *visible* program is on-air, so the next background run
+   * actually re-queries YouTube instead of being short-circuited by the not-found gate.
+   * search?eventType=live can report 0 results for a channel that is demonstrably live
+   * (the index lags, and sometimes just misses an ongoing broadcast), and freezing the
+   * channel for 15 minutes on the first miss is what turns that into a lost program.
+   */
+  private readonly NOT_FOUND_ON_AIR_RETRY_TTL = 120; // 2 minutes
+  /**
+   * Minimum time between *counted* attempts. Retries happen every couple of minutes while
+   * a program is on-air, but the escalation ladder must stay time-based: without this, three
+   * fast retries would escalate a channel to not-found (and email about it) within minutes.
+   */
+  private readonly NOT_FOUND_ATTEMPT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
 
   // YouTube API usage tracking removed - no longer needed
 
@@ -970,45 +988,66 @@ export class YoutubeLiveService {
       // Track API usage
       // YouTube API usage tracking removed
 
-      const requestUrl = `${this.apiUrl}/search?part=snippet&channelId=${channelId}&eventType=live&type=video&key=${this.apiKey}&maxResults=5`;
-      this.logger.debug(
-        `🔍 [getLiveStreams] Making request for ${handle}: ${requestUrl}`,
-      );
-      this.logger.debug(
-        `🔍 [getLiveStreams] Using API key: ${this.apiKey ? this.apiKey.substring(0, 10) + '...' : 'NOT_SET'}`,
-      );
-
-      const { data } = await axios.get(`${this.apiUrl}/search`, {
-        timeout: this.YOUTUBE_API_TIMEOUT_MS,
-        params: {
-          part: 'snippet',
-          channelId,
-          eventType: 'live',
-          type: 'video',
-          key: this.apiKey,
-          maxResults: 5, // YouTube API limitation: maxResults should be 1-5 for eventType=live
-          regionCode: 'AR',
-        },
-      });
-
-      this.logger.debug(
-        `🔍 [getLiveStreams] Response for ${handle}:`,
-        JSON.stringify(data, null, 2),
+      // Retrying every 2 minutes with a 100-unit search would cost ~1.5k quota units per
+      // program block that never goes live. Inside the retry window we skip the search and
+      // let the uploads fallback below (~4 units) do the work — which the Luzu TV incident
+      // showed is also the more reliable of the two: search reported 0 results for a
+      // broadcast that had been live for 49 minutes and sat at position 0 of the uploads
+      // playlist. Counted attempts still run the search, because a long-running stream can
+      // fall outside the 3 most recent uploads once enough shorts are published after it.
+      const uploadsOnlyRetry = await this.isUploadsOnlyRetry(
+        handle,
+        currentProgramName,
+        cronType,
       );
 
-      const allStreams: LiveStream[] = (data.items || []).map((item: any) => ({
-        videoId: item.id.videoId,
-        title: item.snippet.title,
-        publishedAt: item.snippet.publishedAt,
-        description: item.snippet.description,
-        thumbnailUrl: item.snippet.thumbnails?.medium?.url,
-        channelTitle: item.snippet.channelTitle,
-        liveBroadcastContent: item.snippet.liveBroadcastContent, // Add this for validation
-      }));
+      let allStreams: LiveStream[] = [];
 
-      this.logger.debug(
-        `🔍 [getLiveStreams] Found ${allStreams.length} streams from search API for ${handle}. liveBroadcastContent from search: ${allStreams.map((s) => `${s.videoId}:${s.liveBroadcastContent}`).join(', ')}`,
-      );
+      if (uploadsOnlyRetry) {
+        this.logger.debug(
+          `💸 [getLiveStreams] Skipping search for ${handle} (inside not-found retry window), relying on uploads fallback`,
+        );
+      } else {
+        const requestUrl = `${this.apiUrl}/search?part=snippet&channelId=${channelId}&eventType=live&type=video&key=${this.apiKey}&maxResults=5`;
+        this.logger.debug(
+          `🔍 [getLiveStreams] Making request for ${handle}: ${requestUrl}`,
+        );
+        this.logger.debug(
+          `🔍 [getLiveStreams] Using API key: ${this.apiKey ? this.apiKey.substring(0, 10) + '...' : 'NOT_SET'}`,
+        );
+
+        const { data } = await axios.get(`${this.apiUrl}/search`, {
+          timeout: this.YOUTUBE_API_TIMEOUT_MS,
+          params: {
+            part: 'snippet',
+            channelId,
+            eventType: 'live',
+            type: 'video',
+            key: this.apiKey,
+            maxResults: 5, // YouTube API limitation: maxResults should be 1-5 for eventType=live
+            regionCode: 'AR',
+          },
+        });
+
+        this.logger.debug(
+          `🔍 [getLiveStreams] Response for ${handle}:`,
+          JSON.stringify(data, null, 2),
+        );
+
+        allStreams = (data.items || []).map((item: any) => ({
+          videoId: item.id.videoId,
+          title: item.snippet.title,
+          publishedAt: item.snippet.publishedAt,
+          description: item.snippet.description,
+          thumbnailUrl: item.snippet.thumbnails?.medium?.url,
+          channelTitle: item.snippet.channelTitle,
+          liveBroadcastContent: item.snippet.liveBroadcastContent, // Add this for validation
+        }));
+
+        this.logger.debug(
+          `🔍 [getLiveStreams] Found ${allStreams.length} streams from search API for ${handle}. liveBroadcastContent from search: ${allStreams.map((s) => `${s.videoId}:${s.liveBroadcastContent}`).join(', ')}`,
+        );
+      }
 
       // Filter out scheduled streams - only keep actually live streams
       const liveStreams: LiveStream[] = [];
@@ -1058,20 +1097,24 @@ export class YoutubeLiveService {
         );
       }
 
-      if (liveStreams.length === 0 && currentProgramIsPremiere) {
-        // Fallback: YouTube premieres (estrenos) don't appear in search?eventType=live
-        // but ARE reported as liveBroadcastContent=live by the videos API.
-        // Only runs when the current program is flagged as is_premiere to avoid
-        // wasting quota on channels that are genuinely offline.
-        const premiereStream = await this.findActivePremiereFromUploads(
+      if (liveStreams.length === 0 && currentProgramName) {
+        // Fallback via the uploads playlist. Two cases where search?eventType=live returns
+        // nothing even though the channel IS live:
+        //   1. Premieres (estrenos) never show up in search?eventType=live at all.
+        //   2. The search index lags behind the real start of a broadcast (minutes), so a
+        //      program that just started looks offline and gets escalated to not-found.
+        // videos?part=snippet reports both correctly as liveBroadcastContent=live, and this
+        // path costs ~4 quota units (playlistItems + up to 3 videos) vs 100 for a search.
+        // Gated on currentProgramName so it only runs while a visible program is on-air.
+        const uploadStream = await this.findActiveLiveFromUploads(
           channelId,
           handle,
           currentProgramName,
         );
-        if (premiereStream) {
-          liveStreams.push(premiereStream);
+        if (uploadStream) {
+          liveStreams.push(uploadStream);
           this.logger.debug(
-            `🎬 [Premiere] Found active premiere for ${handle}: ${premiereStream.videoId} - ${premiereStream.title}`,
+            `🎬 [UploadsFallback] Found active live/premiere for ${handle} (is_premiere=${currentProgramIsPremiere}): ${uploadStream.videoId} - ${uploadStream.title}`,
           );
         }
       }
@@ -1255,12 +1298,13 @@ export class YoutubeLiveService {
   }
 
   /**
-   * Fallback for YouTube premieres (estrenos): the search?eventType=live endpoint does not
-   * return premieres, but videos?part=snippet correctly reports them as liveBroadcastContent=live.
+   * Fallback for broadcasts that search?eventType=live misses: premieres (estrenos) are never
+   * returned by it, and a freshly started live stream can take several minutes to reach the
+   * search index. videos?part=snippet reports both as liveBroadcastContent=live.
    * Fetches the channel's 3 most recent uploads via playlistItems (1 quota unit) and checks
    * each one with isVideoLive().
    */
-  private async findActivePremiereFromUploads(
+  private async findActiveLiveFromUploads(
     channelId: string,
     handle: string,
     currentProgramName: string | null = null,
@@ -1281,7 +1325,7 @@ export class YoutubeLiveService {
 
       const items: any[] = data.items || [];
       this.logger.debug(
-        `🎬 [Premiere] Checking ${items.length} recent uploads for ${handle}`,
+        `🎬 [UploadsFallback] Checking ${items.length} recent uploads for ${handle}`,
       );
 
       const liveStreams: LiveStream[] = [];
@@ -1318,7 +1362,7 @@ export class YoutubeLiveService {
             ),
         );
         this.logger.debug(
-          `🎬 [Premiere] Multiple live premieres for ${handle}, selected best match: ${liveStreams[0].videoId} - ${liveStreams[0].title}`,
+          `🎬 [UploadsFallback] Multiple live videos for ${handle}, selected best match: ${liveStreams[0].videoId} - ${liveStreams[0].title}`,
         );
       }
 
@@ -1330,7 +1374,7 @@ export class YoutubeLiveService {
         );
       }
       this.logger.warn(
-        `⚠️ [Premiere] Fallback check failed for ${handle}: ${err.message}`,
+        `⚠️ [UploadsFallback] Check failed for ${handle}: ${err.message}`,
       );
       return null;
     }
@@ -1406,7 +1450,7 @@ export class YoutubeLiveService {
 
     for (const schedule of onAirPrograms) {
       const programName = schedule.program?.name ?? 'Desconocido';
-      const stream = await this.findActivePremiereFromUploads(
+      const stream = await this.findActiveLiveFromUploads(
         channelId,
         handle,
         programName,
@@ -1864,11 +1908,53 @@ export class YoutubeLiveService {
   /**
    * Handle not-found escalation for main cron and manual execution - should extend not-found marks
    */
+  /**
+   * True when the current run is an *uncounted* fast retry of a channel already marked
+   * not-found, and can therefore skip the expensive search in favour of the uploads
+   * playlist.
+   *
+   * Deliberately mirrors the "don't count this attempt" rule in
+   * handleNotFoundEscalationMain, so the cheap path and the uncounted attempts are exactly
+   * the same set of runs: retries stay cheap, and the three counted attempts that drive
+   * escalation still get a full search.
+   */
+  private async isUploadsOnlyRetry(
+    handle: string,
+    currentProgramName: string | null,
+    cronType: 'main' | 'back-to-back-fix' | 'manual',
+  ): Promise<boolean> {
+    // The uploads fallback only runs while a visible program is on-air, and the
+    // back-to-back cron has its own escalation ladder.
+    if (!currentProgramName || cronType === 'back-to-back-fix') return false;
+
+    try {
+      const tracking = await this.redisService.get<AttemptTracking>(
+        `notFoundAttempts:${handle}`,
+      );
+      if (!tracking || tracking.escalated) return false;
+      return (
+        Date.now() - tracking.lastAttempt < this.NOT_FOUND_ATTEMPT_INTERVAL_MS
+      );
+    } catch (err) {
+      // Never let a Redis hiccup silently downgrade detection — fall back to the search.
+      this.logger.warn(
+        `⚠️ [getLiveStreams] Could not read not-found tracking for ${handle}: ${err instanceof Error ? err.message : err}`,
+      );
+      return false;
+    }
+  }
+
   private async handleNotFoundEscalationMain(
     channelId: string,
     handle: string,
     notFoundKey: string,
   ): Promise<void> {
+    // Whether a visible program is currently on-air. Drives how long the not-found
+    // mark lives: if nothing is scheduled the channel is just offline and there is
+    // nothing to retry for, but if a program *should* be streaming we want to keep
+    // asking YouTube.
+    let visibleProgramOnAir = false;
+
     // Visibility guard: do not escalate for non-visible channel/program
     try {
       const channel = await this.channelsRepository.findOne({
@@ -1902,6 +1988,7 @@ export class YoutubeLiveService {
         );
         return;
       }
+      visibleProgramOnAir = !!currentProgram;
     } catch (visErr) {
       this.logger.warn(
         `⚠️ [Main] Visibility check failed for ${handle}: ${visErr instanceof Error ? visErr.message : visErr}`,
@@ -1933,10 +2020,17 @@ export class YoutubeLiveService {
       );
 
       // Phase 4: Set not-found mark for main cron and manual execution - both formats
-      await this.redisService.set(notFoundKey, '1', 900);
-      await this.redisService.set(`videoIdNotFound:${handle}`, '1', 900);
+      const firstAttemptTTL = visibleProgramOnAir
+        ? this.NOT_FOUND_ON_AIR_RETRY_TTL
+        : this.NOT_FOUND_TTL;
+      await this.redisService.set(notFoundKey, '1', firstAttemptTTL);
+      await this.redisService.set(
+        `videoIdNotFound:${handle}`,
+        '1',
+        firstAttemptTTL,
+      );
       this.logger.debug(
-        `🚫 [First attempt] No live video for ${handle}, marking not-found for 15 minutes`,
+        `🚫 [First attempt] No live video for ${handle}, marking not-found for ${firstAttemptTTL}s (visibleProgramOnAir=${visibleProgramOnAir})`,
       );
       return;
     }
@@ -1975,6 +2069,32 @@ export class YoutubeLiveService {
           Math.floor(ttlUntilProgramEndForNotFound / 1000),
         );
       }
+      return;
+    }
+
+    // Retry cadence is decoupled from the escalation ladder. While a visible program is
+    // on-air the mark only lives 2 minutes so the next run re-queries YouTube, but an
+    // attempt is only counted once the normal 15-minute window has elapsed — otherwise
+    // those fast retries would reach 3 attempts (and send the escalation email) within
+    // minutes of a program starting. lastAttempt is deliberately left untouched here.
+    const sinceLastAttempt = Date.now() - tracking.lastAttempt;
+    if (
+      visibleProgramOnAir &&
+      sinceLastAttempt < this.NOT_FOUND_ATTEMPT_INTERVAL_MS
+    ) {
+      await this.redisService.set(
+        notFoundKey,
+        '1',
+        this.NOT_FOUND_ON_AIR_RETRY_TTL,
+      );
+      await this.redisService.set(
+        `videoIdNotFound:${handle}`,
+        '1',
+        this.NOT_FOUND_ON_AIR_RETRY_TTL,
+      );
+      this.logger.debug(
+        `🔁 [Retry] Still no live video for ${handle}, retrying in ${this.NOT_FOUND_ON_AIR_RETRY_TTL}s (attempt ${tracking.attempts} stands, ${Math.round(sinceLastAttempt / 1000)}s since last counted attempt)`,
+      );
       return;
     }
 
@@ -2029,10 +2149,17 @@ export class YoutubeLiveService {
       }
     } else {
       // Second attempt - extend not-found mark for main cron and manual execution - both formats
-      await this.redisService.set(notFoundKey, '1', 900);
-      await this.redisService.set(`videoIdNotFound:${handle}`, '1', 900);
+      const secondAttemptTTL = visibleProgramOnAir
+        ? this.NOT_FOUND_ON_AIR_RETRY_TTL
+        : this.NOT_FOUND_TTL;
+      await this.redisService.set(notFoundKey, '1', secondAttemptTTL);
+      await this.redisService.set(
+        `videoIdNotFound:${handle}`,
+        '1',
+        secondAttemptTTL,
+      );
       this.logger.debug(
-        `🚫 [Second attempt] Still no live video for ${handle}, extending not-found for another 15 minutes`,
+        `🚫 [Second attempt] Still no live video for ${handle}, extending not-found for ${secondAttemptTTL}s (visibleProgramOnAir=${visibleProgramOnAir})`,
       );
     }
 
@@ -2230,19 +2357,21 @@ export class YoutubeLiveService {
         applyOverrides: true,
       });
 
-      // Find current program for this channel
-      const currentProgram = schedules.find((schedule) => {
-        const channelIdFromSchedule =
-          schedule.program?.channel?.youtube_channel_id;
-        if (channelIdFromSchedule !== channelId) return false;
+      // Find current program for this channel (hidden programs don't define the block end)
+      const currentProgram = filterVisibleSchedules(schedules).find(
+        (schedule) => {
+          const channelIdFromSchedule =
+            schedule.program?.channel?.youtube_channel_id;
+          if (channelIdFromSchedule !== channelId) return false;
 
-        const startMinutes = this.convertTimeToMinutes(schedule.start_time);
-        const endMinutes = this.convertTimeToMinutes(schedule.end_time);
-        return (
-          startMinutes <= currentTimeInMinutes &&
-          endMinutes > currentTimeInMinutes
-        );
-      });
+          const startMinutes = this.convertTimeToMinutes(schedule.start_time);
+          const endMinutes = this.convertTimeToMinutes(schedule.end_time);
+          return (
+            startMinutes <= currentTimeInMinutes &&
+            endMinutes > currentTimeInMinutes
+          );
+        },
+      );
 
       if (currentProgram) {
         const endMinutes = this.convertTimeToMinutes(currentProgram.end_time);
@@ -2289,7 +2418,7 @@ export class YoutubeLiveService {
           applyOverrides: true,
         });
 
-        const channelSchedules = schedules.filter(
+        const channelSchedules = filterVisibleSchedules(schedules).filter(
           (s) => s.program?.channel?.youtube_channel_id === channelId,
         );
 


### PR DESCRIPTION
Release 1.41.0 — `develop` → `main`. Merge dispara el deploy automático a producción en Railway.

Contenido: PR #400 (`6ae4fd1`), que salió de dos investigaciones distintas.

## Added

- **Verificación de propiedad del device en `POST /push/fcm/subscribe`** (modo report-only). El endpoint no tenía ningún guard, y como la fila de `devices` queda ligada a su usuario para siempre (el unsubscribe solo limpia el token), cualquiera con el `deviceId` podía volver a habilitar push para esa cuenta. Eso permitió que un mobile con la sesión ya muerta se re-suscribiera 0,7s después de desregistrarse y siguiera recibiendo notificaciones cinco días. Usa `OptionalJwtAuthGuard`: un device nunca reclamado sigue registrándose, uno con dueño no puede re-suscribirse anónimamente.
- **Filtro global de excepciones** que loguea todo error HTTP con endpoint, status, `deviceId`, `userId` y versión de app. En el ciclo de vida de Nest los guards corren *antes* que los interceptors, así que `PerformanceInterceptor` nunca veía un rechazo de `JwtAuthGuard`: los 401 no dejaban ningún rastro en producción.

## Fixed

- **Programas ocultos manejando la detección de live.** El cron leía schedules con `findAll()` sin filtrar visibilidad, así que un `is_visible=false` podía ser elegido como programa actual y comparado contra el título del video en vivo del programa visible del mismo bloque, dando 0% de match. Nuevo `scheduleVisibility.util`. El backoffice no se ve afectado: usa sus propias queries.
- **Streams que nunca se detectaban como en vivo.** `search?eventType=live` devuelve 0 items para canales que están transmitiendo. El fallback por playlist de uploads ahora corre siempre que search no encuentra nada con un programa visible al aire, no solo para `is_premiere`.
- **Reintento efectivo mientras hay programa al aire.** La marca `videoIdNotFound` vive 2 minutos en vez de 15 cuando hay un programa visible al aire. La cadencia de reintento quedó desacoplada de la escalera de escalación: un intento solo se cuenta cuando pasaron los 15 minutos originales, así que la escalación sigue requiriendo 3 intentos y ~30 minutos y no manda mail a los pocos minutos de arrancar un programa.

## Performance

- **Los reintentos de not-found ya no gastan un `search`.** Reintentar cada 2 minutos con un search de 100 unidades habría llevado el costo de un bloque programado que nunca sale al aire de ~310 a ~1560 unidades de quota (5x), sin ningún guard diario que lo contenga. Dentro de la ventana de reintento se usa directamente la playlist de uploads (~4 unidades), dejando el bloque en ~350. Los intentos contados siguen ejecutando el search completo.

## Changed

- `unsubscribeFCM` loguea `deviceId` y cantidad de suscripciones borradas — el único registro server-side de que un cliente cerró sesión.
- Las notificaciones de streamers ya no loguean `device unknown`.

## Verificación

- `nest build` ✅
- 109 tests en verde en `src/youtube` + `src/push`, 12 nuevos
- Validado en `staging` (`543b151`)

## Post-deploy

1. **`PUSH_ENFORCE_DEVICE_OWNERSHIP` queda sin setear a propósito.** El guard sale en report-only porque los builds de mobile anteriores a 1.0.17 no adjuntan el JWT a `/push/fcm/subscribe`; enforcear de una les cortaría el registro de push. Revisar `🚫 [PushService] FCM subscribe ownership mismatch` junto al breakdown de versiones en Datadog RUM (`@service:la-guia-del-streaming-mobile`, agrupado por `version`) y recién ahí activarlo — es variable de entorno, no necesita redeploy.
2. Confirmar en logs que `🎬 [UploadsFallback]` encuentra streams para canales que search reporta en 0, y que `💸 [getLiveStreams] Skipping search` aparece en los reintentos.
3. Mobile PR #15 (1.0.19) queda listo para buildear una vez que esto esté en producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVDoNvQXq4yiowrZHXGzbs
