### PR TITLE
feat: programas especiales basados en un programa existente

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.42.0] - 2026-08-18
+
+### Added
+
+- **Programas especiales basados en un programa existente**: los weekly overrides de tipo `create` arman un programa virtual desde cero, así que una transmisión especial de un programa que ya existe perdía todo lo del original y el admin retipeaba nombre, imagen y playlist y volvía a elegir los panelistas a mano. Se agregan dos campos a `specialProgram`, ambos opcionales y guardados en Redis junto al resto del override (sin migración): `sourceProgramId`, el programa real en que se basa el especial, validado contra la DB al crear —tanto en el alta simple como en la bulk— para no dejar una referencia colgada que la resolución de push descartaría en silencio; y `style_override`, para que el especial se vea igual que el programa original en lugar de caer al estilo por defecto. El schedule virtual propaga los dos. El autocompletado que los llena vive en el backoffice (frontend 1.31.0); un especial creado sin elegir programa base sigue funcionando exactamente como antes.
+
+### Fixed
+
+- **Los programas especiales nunca disparaban notificaciones**: el cron de push filtra por `is_visible === true`, y el programa virtual que arma `applyWeeklyOverrides` no traía el campo, así que todos los especiales quedaban afuera. El resto del código chequea `!== false`, por eso el hueco solo se manifestaba acá. Ahora el virtual declara `is_visible: true` explícito —existen porque un admin los programó, no hay caso en que sean invisibles— y las suscripciones se resuelven por `sourceProgramId ?? program.id`, de modo que los suscriptos del programa original reciben la push de la transmisión especial. Un especial sin programa base sigue sin notificar: no hay programa en la DB al que alguien pueda estar suscripto.
+- **Un especial al aire podía tumbar el cron de notificaciones entero**: el `program.id` de un programa virtual es el string `virtual_program_...`, y mandarlo dentro de `In(programIds)` contra la columna integer de suscripciones hace fallar la query completa, no solo esa fila. Hasta ahora estaba tapado por el filtro de `is_visible` que descartaba los especiales antes de llegar ahí; volverlos visibles lo habría destapado. Los schedules sin un id numérico que resolver se filtran antes de armar la query.
+- **Push duplicada cuando un programa arranca en varios schedules a la vez**: su emisión regular más una transmisión especial basada en ella, o un mismo especial creado en varios canales, son schedules distintos que empiezan en el mismo minuto y resuelven al mismo programa. Se manda una sola notificación por (suscripción de push, programa).
+
+
 ## [1.41.0] - 2026-08-13
 
 ### Added

--- a/src/push/push.scheduler.spec.ts
+++ b/src/push/push.scheduler.spec.ts
@@ -512,6 +512,97 @@ describe('PushScheduler', () => {
       expect(mockPushService.sendNotification).not.toHaveBeenCalled();
     });
 
+    it('should notify subscribers of the source program for a special program', async () => {
+      // Special programs are virtual: string id, no DB row. When the admin based
+      // it on an existing program, its subscribers must still be notified.
+      const specialSchedule = {
+        ...mockSchedule,
+        id: 'virtual_special_channel_1_plp_friday_2023-11-27',
+        program: {
+          ...mockProgram,
+          id: 'virtual_program_special_channel_1_plp_friday_2023-11-27',
+          name: 'Test Program - Especial',
+          sourceProgramId: mockProgram.id,
+        },
+      };
+
+      const schedulesService = module.get(SchedulesService);
+      jest
+        .spyOn(schedulesService, 'findAll')
+        .mockResolvedValue([specialSchedule]);
+      mockUserSubscriptionRepository.find.mockResolvedValue([
+        mockUserSubscription,
+      ]);
+      mockPushService.sendNotification.mockResolvedValue(true);
+
+      await scheduler.handleNotificationsCron();
+
+      // Subscriptions looked up by the real program id, never the virtual string
+      expect(mockUserSubscriptionRepository.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { program: { id: In([mockProgram.id]) }, isActive: true },
+        }),
+      );
+
+      // …but the notification carries the special's own name
+      expect(mockPushService.sendNotification).toHaveBeenCalledWith(
+        mockUser.devices[0].pushSubscriptions[0],
+        expect.objectContaining({ title: 'Test Program - Especial' }),
+      );
+    });
+
+    it('should skip special programs that are not based on an existing program', async () => {
+      const standaloneSpecial = {
+        ...mockSchedule,
+        id: 'virtual_special_channel_1_gala_friday_2023-11-27',
+        program: {
+          ...mockProgram,
+          id: 'virtual_program_special_channel_1_gala_friday_2023-11-27',
+          name: 'Gala especial',
+          sourceProgramId: undefined,
+        },
+      };
+
+      const schedulesService = module.get(SchedulesService);
+      jest
+        .spyOn(schedulesService, 'findAll')
+        .mockResolvedValue([standaloneSpecial]);
+
+      await scheduler.handleNotificationsCron();
+
+      // No numeric id to resolve — bailing out also keeps the virtual string id
+      // out of the integer-typed subscription query.
+      expect(mockUserSubscriptionRepository.find).not.toHaveBeenCalled();
+      expect(mockPushService.sendNotification).not.toHaveBeenCalled();
+    });
+
+    it('should send a single push when a program airs twice at the same time', async () => {
+      // Regular broadcast + a special based on it, both starting now.
+      const specialSchedule = {
+        ...mockSchedule,
+        id: 'virtual_special_channel_1_plp_friday_2023-11-27',
+        program: {
+          ...mockProgram,
+          id: 'virtual_program_special_channel_1_plp_friday_2023-11-27',
+          name: 'Test Program - Especial',
+          sourceProgramId: mockProgram.id,
+        },
+      };
+
+      const schedulesService = module.get(SchedulesService);
+      jest
+        .spyOn(schedulesService, 'findAll')
+        .mockResolvedValue([mockSchedule, specialSchedule]);
+      mockUserSubscriptionRepository.find.mockResolvedValue([
+        mockUserSubscription,
+      ]);
+      mockPushService.sendNotification.mockResolvedValue(true);
+
+      await scheduler.handleNotificationsCron();
+
+      expect(mockPushService.sendNotification).toHaveBeenCalledTimes(1);
+    });
+
     it('should handle null/undefined push subscriptions gracefully', async () => {
       const deviceWithNullSubscriptions = {
         ...mockUser.devices[0],

--- a/src/push/push.scheduler.ts
+++ b/src/push/push.scheduler.ts
@@ -33,6 +33,26 @@ export class PushScheduler {
     private readonly schedulesService: SchedulesService,
   ) {}
 
+  /**
+   * Programa al que se le buscan suscriptores para este schedule.
+   *
+   * Los schedules reales traen un program.id numérico. Los programas especiales
+   * son virtuales: su id es un string (`virtual_program_...`) que no matchea
+   * ninguna suscripción, así que solo notifican si el admin los creó a partir de
+   * un programa existente (sourceProgramId). Devuelve null cuando no hay a quién
+   * notificar — filtrar esos casos también evita mandar el id string a una query
+   * sobre una columna integer.
+   */
+  private resolveNotifyProgramId(program: {
+    id: unknown;
+    sourceProgramId?: unknown;
+  }): number | null {
+    const candidate = program?.sourceProgramId ?? program?.id;
+    return typeof candidate === 'number' && Number.isInteger(candidate)
+      ? candidate
+      : null;
+  }
+
   @Cron(CronExpression.EVERY_MINUTE, {
     timeZone: 'America/Argentina/Buenos_Aires',
   })
@@ -54,10 +74,28 @@ export class PushScheduler {
       skipCache: false, // ✅ IMPORTANTE: Usar cache para reducir carga en DB
     });
 
-    // Filtrar schedules que empiezan en 10 min, excluyendo programas ocultos
-    const dueSchedules = allSchedules.filter(
-      (s) => s.start_time === timeString && s.program?.is_visible === true,
-    );
+    // Filtrar schedules que empiezan en 10 min, excluyendo programas ocultos.
+    // Los programas especiales (weekly overrides de tipo `create`) tienen un
+    // program.id virtual de tipo string: solo notifican si el admin los basó en
+    // un programa real, vía sourceProgramId.
+    const dueSchedules = allSchedules
+      .filter(
+        (s) => s.start_time === timeString && s.program?.is_visible === true,
+      )
+      .map((s) => ({
+        schedule: s,
+        notifyProgramId: this.resolveNotifyProgramId(
+          s.program as { id: unknown; sourceProgramId?: unknown },
+        ),
+      }))
+      .filter(
+        (
+          entry,
+        ): entry is {
+          schedule: (typeof allSchedules)[number];
+          notifyProgramId: number;
+        } => entry.notifyProgramId !== null,
+      );
     if (dueSchedules.length === 0) {
       this.logger.debug('Ningún programa coincide.');
       return;
@@ -66,10 +104,11 @@ export class PushScheduler {
       `Encontrados ${dueSchedules.length} programas que coinciden.`,
     );
     this.logger.log(
-      dueSchedules.map((s) => {
+      dueSchedules.map(({ schedule: s, notifyProgramId }) => {
         return {
           id: s.id,
           programId: s.program.id,
+          notifyProgramId,
           programName: s.program.name,
           channelName: s.program.channel?.name,
           start_time: s.start_time,
@@ -80,7 +119,7 @@ export class PushScheduler {
 
     // 3) IDs únicos de programas
     const programIds = Array.from(
-      new Set(dueSchedules.map((s) => s.program.id)),
+      new Set(dueSchedules.map((e) => e.notifyProgramId)),
     );
 
     // 4) Traer subscripciones de usuarios para esos programas
@@ -107,7 +146,7 @@ export class PushScheduler {
     const uniqueChannelHandles = Array.from(
       new Set(
         dueSchedules
-          .map((s) => s.program.channel?.handle)
+          .map((e) => e.schedule.program.channel?.handle)
           .filter((h): h is string => !!h),
       ),
     );
@@ -121,7 +160,12 @@ export class PushScheduler {
     // 6) Enviar notificaciones por programa + usuario (concurrently)
     const pushPromises: Promise<void>[] = [];
 
-    for (const schedule of dueSchedules) {
+    // Un mismo programa puede estar por empezar en varios schedules a la vez
+    // (su emisión regular más una transmisión especial, o un especial creado en
+    // varios canales). Sin esto el suscripto recibiría una push por cada uno.
+    const notified = new Set<string>();
+
+    for (const { schedule, notifyProgramId } of dueSchedules) {
       const program = schedule.program;
       const title = program.name;
       const channelHandle = program.channel?.handle;
@@ -136,7 +180,7 @@ export class PushScheduler {
 
       // subscripciones para este programa específico
       const programSubscriptions = allUserSubscriptions.filter(
-        (sub) => sub.program.id === program.id,
+        (sub) => sub.program.id === notifyProgramId,
       );
 
       for (const subscription of programSubscriptions) {
@@ -156,6 +200,10 @@ export class PushScheduler {
               device.pushSubscriptions.length > 0
             ) {
               for (const pushSub of device.pushSubscriptions) {
+                const dedupeKey = `${pushSub.id}:${notifyProgramId}`;
+                if (notified.has(dedupeKey)) continue;
+                notified.add(dedupeKey);
+
                 pushPromises.push(
                   (async () => {
                     const isNative = !pushSub.p256dh && !pushSub.auth;

--- a/src/schedules/weekly-overrides.service.spec.ts
+++ b/src/schedules/weekly-overrides.service.spec.ts
@@ -173,6 +173,65 @@ describe('WeeklyOverridesService', () => {
       expect(redisService.del).toHaveBeenCalledWith('schedules:week:complete');
     });
 
+    it('should throw NotFoundException when sourceProgramId does not exist', async () => {
+      const dto: WeeklyOverrideDto = {
+        targetWeek: 'current',
+        overrideType: 'create',
+        newStartTime: '14:00',
+        newEndTime: '16:00',
+        newDayOfWeek: 'monday',
+        specialProgram: {
+          name: 'PLP - Especial',
+          channelId: 1,
+          sourceProgramId: 999,
+        },
+      };
+
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(dataSource, 'query').mockResolvedValue([]);
+
+      await expect(service.createWeeklyOverride(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      // A dangling reference must not reach Redis: push resolution would drop it
+      // silently and the special would never notify.
+      expect(redisService.set).not.toHaveBeenCalled();
+    });
+
+    it('should persist sourceProgramId and style when the program exists', async () => {
+      const dto: WeeklyOverrideDto = {
+        targetWeek: 'current',
+        overrideType: 'create',
+        newStartTime: '14:00',
+        newEndTime: '16:00',
+        newDayOfWeek: 'monday',
+        specialProgram: {
+          name: 'PLP - Especial',
+          channelId: 1,
+          sourceProgramId: 42,
+          style_override: 'neon',
+        },
+      };
+
+      jest.spyOn(redisService, 'get').mockResolvedValue(null);
+      jest.spyOn(redisService, 'set').mockResolvedValue(undefined);
+      jest.spyOn(redisService, 'del').mockResolvedValue(undefined);
+      jest.spyOn(dataSource, 'query').mockImplementation((sql: string) => {
+        if (sql.includes('FROM program')) {
+          return Promise.resolve([{ id: 42 }]);
+        }
+        if (sql.includes('FROM channel')) {
+          return Promise.resolve([{ id: 1, name: 'Test Channel' }]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await service.createWeeklyOverride(dto);
+
+      expect(result.specialProgram!.sourceProgramId).toBe(42);
+      expect(result.specialProgram!.style_override).toBe('neon');
+    });
+
     it('should throw BadRequestException when create override missing special program data', async () => {
       const dto: WeeklyOverrideDto = {
         targetWeek: 'current',
@@ -620,6 +679,109 @@ describe('WeeklyOverridesService', () => {
       expect(virtualSchedule!.day_of_week).toBe('monday');
       expect((virtualSchedule as any).isWeeklyOverride).toBe(true);
       expect((virtualSchedule as any).overrideType).toBe('create');
+    });
+
+    it('should carry source program identity onto the virtual schedule', async () => {
+      const schedules = [mockSchedule as any];
+      const weekStartDate = '2024-01-01';
+      const override = {
+        id: 'special_channel_1_plp_monday_2024-01-01',
+        overrideType: 'create',
+        newStartTime: '14:00',
+        newEndTime: '16:00',
+        newDayOfWeek: 'monday',
+        specialProgram: {
+          name: 'PLP - Especial',
+          channelId: 1,
+          channel: {
+            id: 1,
+            name: 'Test Channel',
+            handle: 'test',
+            youtube_channel_id: 'test123',
+            logo_url: null,
+            description: null,
+            order: 1,
+            is_visible: true,
+          },
+          style_override: 'neon',
+          sourceProgramId: 42,
+        },
+      };
+
+      const mockStream = {
+        [Symbol.asyncIterator]: async function* () {
+          yield ['weekly_override:special_channel_1_plp_monday_2024-01-01'];
+        },
+      };
+      jest
+        .spyOn(mockRedisService.client, 'scanStream')
+        .mockReturnValue(mockStream);
+
+      const mockPipeline = {
+        get: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([[null, JSON.stringify(override)]]),
+      };
+      jest
+        .spyOn(mockRedisService.client, 'pipeline')
+        .mockReturnValue(mockPipeline);
+
+      const result = await service.applyWeeklyOverrides(
+        schedules,
+        weekStartDate,
+      );
+
+      const virtualSchedule: any = result.find((s) =>
+        String(s.id).startsWith('virtual_'),
+      );
+      expect(virtualSchedule.program.style_override).toBe('neon');
+      expect(virtualSchedule.program.sourceProgramId).toBe(42);
+      // Explicit `true`, not just "not false": the push scheduler requires it.
+      expect(virtualSchedule.program.is_visible).toBe(true);
+    });
+
+    it('should default style and source when the special stands alone', async () => {
+      const schedules = [mockSchedule as any];
+      const weekStartDate = '2024-01-01';
+      const override = {
+        id: 'special_channel_1_gala_monday_2024-01-01',
+        overrideType: 'create',
+        newStartTime: '14:00',
+        newEndTime: '16:00',
+        newDayOfWeek: 'monday',
+        specialProgram: {
+          name: 'Gala especial',
+          channelId: 1,
+          channel: { id: 1, name: 'Test Channel' },
+        },
+      };
+
+      const mockStream = {
+        [Symbol.asyncIterator]: async function* () {
+          yield ['weekly_override:special_channel_1_gala_monday_2024-01-01'];
+        },
+      };
+      jest
+        .spyOn(mockRedisService.client, 'scanStream')
+        .mockReturnValue(mockStream);
+
+      const mockPipeline = {
+        get: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([[null, JSON.stringify(override)]]),
+      };
+      jest
+        .spyOn(mockRedisService.client, 'pipeline')
+        .mockReturnValue(mockPipeline);
+
+      const result = await service.applyWeeklyOverrides(
+        schedules,
+        weekStartDate,
+      );
+
+      const virtualSchedule: any = result.find((s) =>
+        String(s.id).startsWith('virtual_'),
+      );
+      expect(virtualSchedule.program.style_override).toBeNull();
+      expect(virtualSchedule.program.sourceProgramId).toBeUndefined();
     });
 
     it('should handle mixed overrides (regular + create)', async () => {

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -40,6 +40,11 @@ export interface WeeklyOverrideDto {
     imageUrl?: string;
     stream_url?: string;
     is_premiere?: boolean;
+    style_override?: string | null;
+    // Program this special is based on. Lets the special inherit the real
+    // program's identity for push notifications (subscribers of the original
+    // get notified about the one-off broadcast).
+    sourceProgramId?: number;
   };
 }
 
@@ -97,6 +102,8 @@ export interface BulkWeeklyOverrideDto {
     imageUrl?: string;
     stream_url?: string;
     is_premiere?: boolean;
+    style_override?: string | null;
+    sourceProgramId?: number;
   };
 }
 
@@ -140,6 +147,8 @@ export interface WeeklyOverride {
     imageUrl?: string;
     stream_url?: string;
     is_premiere?: boolean;
+    style_override?: string | null;
+    sourceProgramId?: number;
   };
 }
 
@@ -178,6 +187,27 @@ export class WeeklyOverridesService {
       FRONTEND_URL,
       REVALIDATE_SECRET,
     );
+  }
+
+  /**
+   * A special program may be based on an existing program (an extra broadcast
+   * of a show that already lives in the DB). Validate the reference so we never
+   * store a dangling sourceProgramId that push resolution would silently drop.
+   */
+  private async assertSourceProgramExists(
+    sourceProgramId?: number,
+  ): Promise<void> {
+    if (sourceProgramId === undefined || sourceProgramId === null) return;
+
+    const [row] = await this.dataSource.query(
+      'SELECT id FROM program WHERE id = $1',
+      [sourceProgramId],
+    );
+    if (!row) {
+      throw new NotFoundException(
+        `Source program with ID ${sourceProgramId} not found`,
+      );
+    }
   }
 
   /**
@@ -244,6 +274,7 @@ export class WeeklyOverridesService {
           'Start time, end time, and day of week are required for create overrides',
         );
       }
+      await this.assertSourceProgramExists(dto.specialProgram.sourceProgramId);
     }
 
     // Calculate target week
@@ -551,6 +582,7 @@ export class WeeklyOverridesService {
           'Start time, end time, and day of week are required for create overrides',
         );
       }
+      await this.assertSourceProgramExists(dto.specialProgram.sourceProgramId);
     }
 
     // Validate override type requirements
@@ -1296,6 +1328,13 @@ export class WeeklyOverridesService {
             logo_url: override.specialProgram.imageUrl || '',
             stream_url: override.specialProgram.stream_url || null,
             is_premiere: override.specialProgram.is_premiere ?? false,
+            style_override: override.specialProgram.style_override ?? null,
+            // Specials are always visible — they only exist because an admin
+            // scheduled them. Set explicitly so consumers that require `true`
+            // (push scheduler) don't skip them on an absent field.
+            is_visible: true,
+            // Real program this special stands in for, when there is one.
+            sourceProgramId: override.specialProgram.sourceProgramId,
             channel: channel
               ? {
                   id: channel.id,
@@ -1424,6 +1463,8 @@ export class WeeklyOverridesService {
         'Start time, end time, and day of week are required',
       );
     }
+
+    await this.assertSourceProgramExists(dto.specialProgram.sourceProgramId);
 
     // Calculate target week (same logic as createWeeklyOverride)
     const now = this.dayjs().tz('America/Argentina/Buenos_Aires');


### PR DESCRIPTION
## Contexto

Los weekly overrides de tipo `create` construyen un programa virtual desde cero. Una transmisión especial de un programa que ya existe perdía todo lo del original: el admin retipeaba nombre, imagen y playlist, y volvía a elegir los panelistas a mano.

Este PR es la mitad backend. La mitad frontend (el autocompletado en el backoffice) va en [streaming-guide-frontend#feature/special-program-from-existing](https://github.com/matiasrozenblum/streaming-guide-frontend/tree/feature/special-program-from-existing) y **depende de que esto esté deployado primero**.

## Cambios

Dos campos aditivos en `specialProgram` (viven en Redis, **sin migración**):

- **`sourceProgramId`** — el programa real en que se basa el especial. Se valida contra la DB al crear (single y bulk) para no guardar referencias colgadas.
- **`style_override`** — el especial se ve igual que el programa original en vez de caer al estilo default.

El schedule virtual propaga ambos más un `is_visible: true` explícito. El resto del código chequea `!== false`, pero el push scheduler exige `=== true` y sobre un campo ausente descartaba todos los especiales.

### Push notifications

`push.scheduler.ts` ahora resuelve las suscripciones por `sourceProgramId ?? program.id`, así los suscriptos del programa original reciben la push del especial. Dos cosas que salieron de ahí:

- **Los especiales sin programa de origen se filtran antes de la query.** Su `program.id` es el string `virtual_program_...`, y mandarlo a `In(programIds)` contra la columna integer hubiera reventado el cron entero. Esto es un bug latente que el feature destapó.
- **Dedupe por (push subscription, programa).** Un programa puede arrancar en varios schedules al mismo minuto —su emisión regular más el especial, o un especial creado en varios canales— y era una push por cada uno.

## Compatibilidad

Todo aditivo. Los overrides ya guardados en Redis siguen funcionando (los campos nuevos quedan `undefined` y el comportamiento es el de antes). **Mobile no requiere cambios**: no tiene backoffice, no valida schema en runtime, y su tipo `Schedule` ni declara `style_override` — los campos extra se ignoran.

## Testing

- 751 tests pasan (7 nuevos: 3 en `push.scheduler.spec.ts`, 4 en `weekly-overrides.service.spec.ts`)
- `tsc --noEmit` limpio, eslint en la baseline exacta del repo
- Deployado y andando en staging

### Lo que no se validó en staging

El path de push depende del cron que corre cada minuto buscando schedules que arrancan en 10 minutos exactos. Probarlo de verdad requiere un especial con hora de inicio a ~10 min, un usuario suscripto al programa base y un device registrado — manda pushes reales. Los tres tests nuevos cubren la lógica de resolución, filtrado y dedupe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmT9MtdXhUi1R1kdrUMrnj