### PR TITLE
chore: consolidar PRs de Jules y dejar el linter en cero (1.43.0)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -5,6 +5,18 @@ on:
     branches: [main, develop]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Instalar dependencias
+        run: npm ci
+
+      - name: Verificar linter (sin --fix, falla ante cualquier warning)
+        run: npm run lint:ci
+
   test:
     runs-on: ubuntu-latest
 

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,15 @@
 ## 2025-03-24 - [N+1 Redis Query Avoidance in Streamer Live Status]
 **Learning:** Found N+1 Redis query patterns inside the `getLiveStatuses` method of `StreamerLiveStatusService`. For every requested streamer, it runs `await this.getLiveStatus(id)` concurrently wrapped in `Promise.all`, which executes individual `GET` commands to Redis. This leads to connection overhead and poor performance.
 **Action:** Replace `Promise.all` with individual `get` calls with a single `mget` command to batch the retrieval, mapping the responses back to the input array indices.
+
+## 2026-07-10 - [N+1 DB Query Avoidance in Program Bulk Creation]
+**Learning:** Found an N+1 query pattern inside the `createBulk` method of `ProgramsService`, where panelists were fetched one by one via `findOne` inside a `.map` wrapped in `Promise.all`.
+**Action:** Replace iterative `findOne` calls with a single `find({ where: { id: In(ids) } })`. Note this also dedups the input ids and drops the now-redundant `.filter(Boolean)`.
+
+## 2026-07-09 - [N+1 Redis Query Avoidance in Config Gating Checks]
+**Learning:** Found an N+1 Redis pattern in `PushScheduler.handleNotificationsCron`: for every unique channel handle it awaited `configService.canFetchLive(handle)`, each of which issues its own `GET` commands.
+**Action:** Added `ConfigService.canFetchLiveBulk(handles)`, which batches the cached reads via `mget`. Ante cualquier cache miss delega en `canFetchLive(handle)` para no alterar la precedencia de fallback (por canal -> global -> DB) ni el warming del cache.
+
+## 2026-08-18 - [Un PR por hallazgo, no uno por dia]
+**Learning:** Se acumularon 12 PRs abiertos que en realidad eran 3 cambios distintos: el mismo N+1 de `ProgramsService.createBulk` fue "descubierto" y re-parcheado 10 veces en dias consecutivos.
+**Action:** Antes de abrir un PR, revisar los PRs abiertos existentes. Si el hallazgo ya tiene un PR, no abrir otro. Ademas: nunca reformatear archivos no relacionados (varios PRs des-formateaban `src/migrations/*` a lineas largas, rompiendo prettier).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Todas las modificaciones importantes de este proyecto se documentarán en este a
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es/1.0.0/)
 y este proyecto utiliza [SemVer](https://semver.org/lang/es/).
 
+## [1.43.0] - 2026-08-18
+
+### Performance
+
+- **N+1 al asignar panelistas en la creación bulk de programas**: `ProgramsService.createBulk` resolvía los panelistas con un `findOne` por id dentro de un `Promise.all`, así que crear un programa en N canales con M panelistas disparaba M queries independientes. Pasa a un único `find({ id: In(...) })`. De paso deduplica ids repetidos en el DTO y vuelve innecesario el `filter(Boolean)` posterior, porque `find` no devuelve huecos.
+- **N+1 de Redis en el gating de configuración del cron de push**: `handleNotificationsCron` evaluaba `configService.canFetchLive(handle)` por cada handle único, y cada llamada emite sus propios `GET` de `youtube.fetch_enabled` y `youtube.fetch_override_holiday`. Se agrega `ConfigService.canFetchLiveBulk(handles)`, que batchea las lecturas cacheadas con `mget` y resuelve el feriado una sola vez para todo el lote. Ante cualquier cache miss delega en `canFetchLive(handle)`, de modo que la precedencia de fallback (por canal → global → DB) y el calentamiento del cache quedan exactamente como estaban. La lógica de feriado se extrae a `isHolidayToday()` para no quedar duplicada entre ambos caminos.
+
+### Fixed
+
+- **Faltaba el `await` en la revalidación de `ConfigService.set`**: era el único de los más de veinte call sites de `notifyAndRevalidate` del repo que no lo esperaba, así que al cambiar `holiday.custom_dates` la respuesta del endpoint podía volver antes de que el frontend se revalidara, y un rechazo quedaba como unhandled rejection. Afecta solo al backoffice.
+- **Promesas flotantes y callbacks async en timers**: `main.ts`, `ConnectionPoolMonitorService`, `SchedulesService`, `YoutubeLiveService` y `YoutubeController` pasaban funciones `async` a `setTimeout`/`setInterval`/`setImmediate`, que descartan la promesa devuelta. Todos los cuerpos ya capturaban sus propios errores, así que el comportamiento no cambia, pero ahora el fire-and-forget es explícito y ningún rechazo puede escaparse sin handler.
+
+### Changed
+
+- **El linter queda en cero hallazgos y bloquea en CI**: `npm run lint` levantaba 3082 problemas (2728 errores y 354 warnings), suficiente ruido como para que nadie lo mirara y cada cambio nuevo sumara más. El 82% era la familia `no-unsafe-*`, que solo se elimina de verdad retipando los 71 servicios de `src/`: se apaga por configuración, coherente con el `no-explicit-any: off` que el proyecto ya tenía. `require-await`, `no-require-imports` y `unbound-method` (este último solo en specs) se apagan tras revisar caso por caso que son usos deliberados —`async` como contrato de interfaz, lazy imports para cortar dependencias circulares, mocks de jest—. Se mantienen en `error` las reglas que atrapan bugs reales: `no-floating-promises`, `no-misused-promises` y `no-unused-vars`. Se eliminan 60 imports muertos y se marcan con prefijo `_` las variables y parámetros que deben existir pero no se usan. Nuevo script `lint:ci` (sin `--fix`, `--max-warnings=0`) y job `lint` en el workflow de PRs, para que ningún cambio nuevo vuelva a acumular deuda.
+
 ## [1.42.0] - 2026-08-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,28 @@ Deployed on Railway (staging + production).
 - JWT auth with access + refresh tokens, social login (Google, Apple)
 - Swagger API docs auto-generated from decorators
 
+## Linting (OBLIGATORIO)
+El repo está en **cero errores y cero warnings** de ESLint. Mantenerlo así
+no es opcional: el job `lint` de CI corre `npm run lint:ci` en cada PR
+contra `main`/`develop` y falla ante cualquier hallazgo.
+
+- **Antes de dar por terminado cualquier cambio, corré `npm run lint:ci`.**
+  Tiene que salir con exit code 0.
+- `npm run lint` corre con `--fix` **sobre todo el repo**, así que ensucia
+  el commit con archivos que no tocaste. Para arreglar lo tuyo usá
+  `npx eslint <archivos> --fix` y nunca hagas `git add -A` después.
+- Nunca silencies un hallazgo nuevo con `eslint-disable` para "que pase".
+  Si una regla realmente no aplica al proyecto, se discute y se cambia en
+  `eslint.config.mjs` con un comentario que explique el porqué; si aplica,
+  se arregla el código.
+- Reglas en `error` que atrapan bugs reales y no se relajan:
+  `no-floating-promises`, `no-misused-promises`, `no-unused-vars`.
+- Para variables o parámetros que deben existir pero no se usan (firmas de
+  interfaz, destructuring), prefijalos con `_` en vez de borrarlos.
+- La familia `no-unsafe-*`, `require-await`, `no-require-imports` y
+  `unbound-method` (en specs) están apagadas a propósito. El razonamiento
+  está comentado en `eslint.config.mjs`; leelo antes de tocarlas.
+
 ## Coding Conventions
 - DTOs use `class-validator` decorators for input validation
 - Services are `@Injectable()`, follow NestJS DI pattern
@@ -42,7 +64,8 @@ Deployed on Railway (staging + production).
 ## Scripts
 - `npm run start:dev` - Dev with hot reload
 - `npm run build` - Compile TypeScript
-- `npm run lint` - ESLint with auto-fix
+- `npm run lint` - ESLint with auto-fix (⚠️ corre sobre todo el repo)
+- `npm run lint:ci` - ESLint sin --fix, falla ante cualquier warning (el que corre CI)
 - `npm test` - Jest unit tests
 - `npm run test:e2e` - End-to-end tests
 - `npm run migration:run` - Apply pending migrations

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,8 +28,16 @@ export default tseslint.config(
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-floating-promises': 'warn',
-      '@typescript-eslint/no-unsafe-argument': 'warn'
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrors: 'none',
+          ignoreRestSiblings: true,
+        },
+      ],
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['eslint.config.mjs'],
+    ignores: ['eslint.config.mjs', 'dist/**', 'coverage/**', 'node_modules/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,
@@ -27,8 +27,9 @@ export default tseslint.config(
   },
   {
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
+      // --- Reglas que SI atrapan bugs reales: se mantienen en error ---
       '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-misused-promises': 'error',
       '@typescript-eslint/no-unused-vars': [
         'error',
         {
@@ -38,6 +39,41 @@ export default tseslint.config(
           ignoreRestSiblings: true,
         },
       ],
+
+      // --- Decisiones explicitas del proyecto ---
+
+      // El proyecto acepta `any` de forma deliberada (respuestas de APIs
+      // externas, payloads de webhooks, filas crudas de TypeORM). Dejar
+      // no-explicit-any en off pero marcar cada *uso* de un any generaba
+      // ~2500 hallazgos sin valor accionable, asi que la familia no-unsafe-*
+      // se apaga por coherencia con esa misma decision.
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-member-access': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'off',
+      '@typescript-eslint/no-unsafe-call': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-enum-comparison': 'off',
+
+      // require() es intencional en los pocos lugares donde aparece: lazy
+      // import para cortar dependencias circulares (weekly-overrides ->
+      // schedules), carga por path de la service-account de Firebase y
+      // dependencias pesadas que solo se cargan si se usan.
+      '@typescript-eslint/no-require-imports': 'off',
+
+      // `async` se usa como contrato de interfaz: wrappers de jsonwebtoken,
+      // hooks de Passport/NestJS y factories que deben devolver Promise
+      // aunque su cuerpo sea sincronico. Quitar el async convertiria los
+      // rechazos en throws sincronicos, cambiando el comportamiento.
+      '@typescript-eslint/require-await': 'off',
+    },
+  },
+  {
+    // Los tests usan mocks sin tipar y pasan metodos sin bindear a expect(),
+    // que es el uso idiomatico de jest y no un problema real.
+    files: ['**/*.spec.ts', 'test/**/*.ts'],
+    rules: {
+      '@typescript-eslint/unbound-method': 'off',
     },
   },
 );

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint:ci": "eslint \"{src,apps,libs,test}/**/*.ts\" --max-warnings=0",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Post,
-  Get,
-  Inject,
-  UseGuards,
-  Query,
-} from '@nestjs/common';
+import { Controller, Post, Get, UseGuards, Query } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { Channel } from './channels/channels.entity';
@@ -18,7 +11,6 @@ import { RedisService } from './redis/redis.service'; // 🔥
 import { AuthGuard } from '@nestjs/passport';
 import * as DateHolidays from 'date-holidays';
 import { Roles } from './auth/roles.decorator';
-import { Response } from 'express';
 import { AppService } from './app.service';
 import { SentryService } from './sentry/sentry.service';
 import { ResourceMonitorService } from './services/resource-monitor.service';

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -311,7 +311,7 @@ export class AppController {
             resolve(true);
           },
         );
-        socket.on('error', (err) => {
+        socket.on('error', (err: Error) => {
           console.log('❌ TCP connection failed:', err.message);
           reject(err);
         });

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -83,7 +83,7 @@ import { ConfigModule as AppConfigModule } from './config/config.module';
           },
           cache: { duration: 30000 },
           // Enhanced error handling for database connection
-          onConnect: async (connection) => {
+          onConnect: async (_connection) => {
             console.log('✅ Database connected successfully');
           },
           onError: (error) => {

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -5,14 +5,13 @@ import { OtpService } from './otp.service';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
-import { UnauthorizedException, BadRequestException } from '@nestjs/common';
 
 describe('AuthController', () => {
   let controller: AuthController;
   let authService: AuthService;
   let otpService: OtpService;
   let usersService: UsersService;
-  let jwtService: JwtService;
+  let _jwtService: JwtService;
 
   const mockUser = {
     id: 1,
@@ -91,7 +90,7 @@ describe('AuthController', () => {
     authService = module.get<AuthService>(AuthService);
     otpService = module.get<OtpService>(OtpService);
     usersService = module.get<UsersService>(UsersService);
-    jwtService = module.get<JwtService>(JwtService);
+    _jwtService = module.get<JwtService>(JwtService);
   });
 
   it('should be defined', () => {
@@ -156,7 +155,7 @@ describe('AuthController', () => {
 
   describe('verifyCode', () => {
     it('should return access and refresh tokens for existing user', async () => {
-      const mockTokens = {
+      const _mockTokens = {
         access_token: 'test-token',
         refresh_token: 'refresh-token',
       };
@@ -547,7 +546,7 @@ describe('AuthController', () => {
     });
 
     it('should not require password for social users', async () => {
-      const mockTokens = {
+      const _mockTokens = {
         access_token: 'test-token',
         refresh_token: 'refresh-token',
       };

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -326,9 +326,8 @@ export class AuthController {
 
     // Validate registration token and get email and origin
     const tokenStart = Date.now();
-    const { email, origin } = await this.authService.verifyRegistrationToken(
-      dto.registration_token,
-    );
+    const { email, origin: _origin } =
+      await this.authService.verifyRegistrationToken(dto.registration_token);
     console.log(
       '⏱️ [AuthController] Token verification took:',
       Date.now() - tokenStart,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -10,7 +10,7 @@ import { User } from '../users/users.entity';
 describe('AuthService', () => {
   let service: AuthService;
   let jwtService: JwtService;
-  let configService: ConfigService;
+  let _configService: ConfigService;
   let usersService: UsersService;
 
   const mockUser = {
@@ -78,7 +78,7 @@ describe('AuthService', () => {
 
     service = module.get<AuthService>(AuthService);
     jwtService = module.get<JwtService>(JwtService);
-    configService = module.get<ConfigService>(ConfigService);
+    _configService = module.get<ConfigService>(ConfigService);
     usersService = module.get<UsersService>(UsersService);
   });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -15,8 +15,8 @@ export class AuthService {
   async loginUser(
     email: string,
     password: string,
-    userAgent?: string,
-    deviceId?: string,
+    _userAgent?: string,
+    _deviceId?: string,
   ): Promise<{ access_token: string; refresh_token: string }> {
     email = email.toLowerCase().trim();
     const user = await this.usersService.findByEmail(email);
@@ -29,7 +29,7 @@ export class AuthService {
     }
 
     // Device creation will be handled by frontend useDeviceId hook with correct user-agent
-    const birthDate =
+    const _birthDate =
       user.birthDate instanceof Date
         ? user.birthDate.toISOString().split('T')[0]
         : typeof user.birthDate === 'string'

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,6 +1,5 @@
 import {
   IsString,
-  IsEmail,
   MinLength,
   IsEnum,
   IsDateString,

--- a/src/auth/guards/optional-jwt-auth.guard.ts
+++ b/src/auth/guards/optional-jwt-auth.guard.ts
@@ -1,4 +1,8 @@
-import { Injectable, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()

--- a/src/banners/banners.service.spec.ts
+++ b/src/banners/banners.service.spec.ts
@@ -8,7 +8,7 @@ import { RedisService } from '../redis/redis.service';
 
 describe('BannersService', () => {
   let service: BannersService;
-  let repository: Repository<Banner>;
+  let _repository: Repository<Banner>;
 
   const mockRepository = {
     find: jest.fn(),
@@ -71,7 +71,7 @@ describe('BannersService', () => {
     }).compile();
 
     service = module.get<BannersService>(BannersService);
-    repository = module.get<Repository<Banner>>(getRepositoryToken(Banner));
+    _repository = module.get<Repository<Banner>>(getRepositoryToken(Banner));
   });
 
   afterEach(() => {

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -202,7 +202,7 @@ export class BannersService {
 
         if (startDate >= endDate) {
           this.logger.error(
-            `Validation failed: start_date (${startDate}) must be before end_date (${endDate})`,
+            `Validation failed: start_date (${startDate.toISOString()}) must be before end_date (${endDate.toISOString()})`,
           );
           throw new BadRequestException('start_date must be before end_date');
         }

--- a/src/banners/banners.service.ts
+++ b/src/banners/banners.service.ts
@@ -5,13 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import {
-  Repository,
-  MoreThanOrEqual,
-  LessThanOrEqual,
-  IsNull,
-  QueryFailedError,
-} from 'typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
 import { Banner } from './banners.entity';
 import { CreateBannerDto } from './dto/create-banner.dto';
 import { UpdateBannerDto } from './dto/update-banner.dto';

--- a/src/banners/dto/create-banner.dto.ts
+++ b/src/banners/dto/create-banner.dto.ts
@@ -7,7 +7,6 @@ import {
   IsInt,
   IsUrl,
   ValidateIf,
-  Validate,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { LinkType, BannerType } from '../banners.entity';

--- a/src/banners/supabase-storage.service.ts
+++ b/src/banners/supabase-storage.service.ts
@@ -66,7 +66,7 @@ export class SupabaseStorageService {
 
     try {
       // Upload file to Supabase Storage
-      const { data, error } = await this.supabase.storage
+      const { data: _data, error } = await this.supabase.storage
         .from(bucketName)
         .upload(filename, file.buffer, {
           contentType: file.mimetype,

--- a/src/categories/categories.controller.spec.ts
+++ b/src/categories/categories.controller.spec.ts
@@ -8,7 +8,7 @@ import { NotFoundException } from '@nestjs/common';
 
 describe('CategoriesController', () => {
   let controller: CategoriesController;
-  let service: CategoriesService;
+  let _service: CategoriesService;
 
   const mockCategory: Category = {
     id: 1,
@@ -41,7 +41,7 @@ describe('CategoriesController', () => {
     }).compile();
 
     controller = module.get<CategoriesController>(CategoriesController);
-    service = module.get<CategoriesService>(CategoriesService);
+    _service = module.get<CategoriesService>(CategoriesService);
   });
 
   afterEach(() => {

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -10,7 +10,7 @@ import { RedisService } from '../redis/redis.service';
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
-  let repository: Repository<Category>;
+  let _repository: Repository<Category>;
 
   const mockCategories: Category[] = [
     {
@@ -79,7 +79,9 @@ describe('CategoriesService', () => {
     }).compile();
 
     service = module.get<CategoriesService>(CategoriesService);
-    repository = module.get<Repository<Category>>(getRepositoryToken(Category));
+    _repository = module.get<Repository<Category>>(
+      getRepositoryToken(Category),
+    );
   });
 
   afterEach(() => {

--- a/src/channels/channels.controller.spec.ts
+++ b/src/channels/channels.controller.spec.ts
@@ -236,7 +236,11 @@ describe('ChannelsController', () => {
     });
 
     it('should handle partial parameters', async () => {
-      const result = await controller.getTodaySchedules(mockReq, 'device456', 'true');
+      const result = await controller.getTodaySchedules(
+        mockReq,
+        'device456',
+        'true',
+      );
 
       expect(result).toEqual([]);
       expect(service.getTodaySchedules).toHaveBeenCalledWith(
@@ -282,7 +286,11 @@ describe('ChannelsController', () => {
     });
 
     it('should handle partial parameters', async () => {
-      const result = await controller.getWeekSchedules(mockReq, 'device789', 'false');
+      const result = await controller.getWeekSchedules(
+        mockReq,
+        'device789',
+        'false',
+      );
 
       expect(result).toEqual([]);
       expect(service.getWeekSchedules).toHaveBeenCalledWith(

--- a/src/channels/channels.integration.spec.ts
+++ b/src/channels/channels.integration.spec.ts
@@ -3,7 +3,6 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { ChannelsController } from '../channels/channels.controller';
 import { ChannelsService } from '../channels/channels.service';
-import {} from '../utils/timezone.util';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
 import { YoutubeLiveService } from '../channels/../youtube/youtube-live.service';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';

--- a/src/channels/channels.integration.spec.ts
+++ b/src/channels/channels.integration.spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { ChannelsController } from '../channels/channels.controller';
 import { ChannelsService } from '../channels/channels.service';
-import { TimezoneUtil } from '../utils/timezone.util';
+import {} from '../utils/timezone.util';
 import { SupabaseStorageService } from '../banners/supabase-storage.service';
 import { YoutubeLiveService } from '../channels/../youtube/youtube-live.service';
 import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
@@ -128,7 +128,7 @@ describe('Channels Endpoints Integration Tests', () => {
     });
 
     it('should handle boolean parameters correctly', async () => {
-      const response = await request(app.getHttpServer())
+      const _response = await request(app.getHttpServer())
         .get('/channels/with-schedules/today')
         .query({
           live_status: 'false',
@@ -144,7 +144,7 @@ describe('Channels Endpoints Integration Tests', () => {
     });
 
     it('should handle missing query parameters', async () => {
-      const response = await request(app.getHttpServer())
+      const _response = await request(app.getHttpServer())
         .get('/channels/with-schedules/today')
         .expect(200);
 
@@ -196,7 +196,7 @@ describe('Channels Endpoints Integration Tests', () => {
     });
 
     it('should handle partial query parameters', async () => {
-      const response = await request(app.getHttpServer())
+      const _response = await request(app.getHttpServer())
         .get('/channels/with-schedules/week')
         .query({
           deviceId: 'partial-device',
@@ -268,7 +268,7 @@ describe('Channels Endpoints Integration Tests', () => {
       // Mock the service to return success for invalid parameters
       mockChannelsService.getTodaySchedules.mockResolvedValue([]);
 
-      const response = await request(app.getHttpServer())
+      const _response = await request(app.getHttpServer())
         .get('/channels/with-schedules/today')
         .query({
           live_status: 'invalid-boolean',

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -21,7 +21,7 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
   let service: ChannelsService;
   let channelsRepository: Repository<Channel>;
   let redisService: RedisService;
-  let schedulesService: SchedulesService;
+  let _schedulesService: SchedulesService;
   let youtubeDiscoveryService: YoutubeDiscoveryService;
 
   const mockChannel = {
@@ -158,7 +158,7 @@ describe('ChannelsService - Channel Handle Change Detection', () => {
       getRepositoryToken(Channel),
     );
     redisService = module.get<RedisService>(RedisService);
-    schedulesService = module.get<SchedulesService>(SchedulesService);
+    _schedulesService = module.get<SchedulesService>(SchedulesService);
     youtubeDiscoveryService = module.get<YoutubeDiscoveryService>(
       YoutubeDiscoveryService,
     );

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -16,7 +16,7 @@ import { ConfigService } from '@/config/config.service';
 import { WeeklyOverridesService } from '@/schedules/weekly-overrides.service';
 import { YoutubeLiveService } from '@/youtube/youtube-live.service';
 import { OptimizedSchedulesService } from '@/youtube/optimized-schedules.service';
-import { getCurrentBlockTTL } from '@/utils/getBlockTTL.util';
+import {} from '@/utils/getBlockTTL.util';
 import { TimezoneUtil } from '../utils/timezone.util';
 import { Category } from '../categories/categories.entity';
 import * as dayjs from 'dayjs';
@@ -561,7 +561,7 @@ export class ChannelsService {
     );
 
     // Group schedules by channel
-    const groupStart = Date.now();
+    const _groupStart = Date.now();
     const schedulesGroupedByChannelId = allSchedules.reduce(
       (acc, schedule) => {
         const channelId = schedule.program?.channel?.id;

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -661,7 +661,14 @@ export class ChannelsService {
   ): Promise<ChannelWithSchedules[]> {
     const today = TimezoneUtil.currentDayOfWeek();
 
-    return this.getChannelsWithSchedules(today, userId, liveStatus, raw, undefined, legacyDeviceId);
+    return this.getChannelsWithSchedules(
+      today,
+      userId,
+      liveStatus,
+      raw,
+      undefined,
+      legacyDeviceId,
+    );
   }
 
   /**

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -16,7 +16,6 @@ import { ConfigService } from '@/config/config.service';
 import { WeeklyOverridesService } from '@/schedules/weekly-overrides.service';
 import { YoutubeLiveService } from '@/youtube/youtube-live.service';
 import { OptimizedSchedulesService } from '@/youtube/optimized-schedules.service';
-import {} from '@/utils/getBlockTTL.util';
 import { TimezoneUtil } from '../utils/timezone.util';
 import { Category } from '../categories/categories.entity';
 import * as dayjs from 'dayjs';

--- a/src/config/config.service.spec.ts
+++ b/src/config/config.service.spec.ts
@@ -16,6 +16,14 @@ describe('ConfigService', () => {
     find: jest.fn(),
   };
 
+  const redisMock = {
+    get: jest.fn(),
+    set: jest.fn(),
+    del: jest.fn(),
+    mget: jest.fn(),
+    client: { set: jest.fn() },
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -26,11 +34,7 @@ describe('ConfigService', () => {
         },
         {
           provide: RedisService,
-          useValue: {
-            get: jest.fn(),
-            set: jest.fn(),
-            del: jest.fn(),
-          },
+          useValue: redisMock,
         },
       ],
     }).compile();
@@ -140,6 +144,101 @@ describe('ConfigService', () => {
       const result = await service.findAll();
       expect(result).toEqual(configs);
       expect(repo.find).toHaveBeenCalledWith({ order: { updated_at: 'DESC' } });
+    });
+  });
+
+  describe('canFetchLiveBulk', () => {
+    const FE = 'config:fetch_enabled:';
+    const HO = 'config:holiday_override:';
+
+    beforeEach(() => {
+      // ensureCacheSeeded: no tomamos el lock, salimos por la rama corta
+      redisMock.client.set.mockResolvedValue(null);
+      mockRepository.find.mockResolvedValue([]);
+    });
+
+    it('returns an empty map for an empty input', async () => {
+      const result = await service.canFetchLiveBulk([]);
+      expect(result.size).toBe(0);
+      expect(redisMock.mget).not.toHaveBeenCalled();
+    });
+
+    it('batches fetch_enabled lookups into a single mget (no N+1)', async () => {
+      // [luzu, olga, global]
+      redisMock.mget.mockResolvedValueOnce([true, true, true]);
+      // no es feriado
+      redisMock.get.mockResolvedValue({ date: 'x', isHoliday: false });
+      jest
+        .spyOn(service as any, 'isHolidayToday')
+        .mockResolvedValue(false as never);
+
+      const result = await service.canFetchLiveBulk(['luzu', 'olga']);
+
+      expect(redisMock.mget).toHaveBeenCalledTimes(1);
+      expect(redisMock.mget).toHaveBeenCalledWith([
+        `${FE}youtube.fetch_enabled.luzu`,
+        `${FE}youtube.fetch_enabled.olga`,
+        `${FE}youtube.fetch_enabled`,
+      ]);
+      expect(result.get('luzu')).toBe(true);
+      expect(result.get('olga')).toBe(true);
+    });
+
+    it('falls back to the global value when a channel has no per-channel config', async () => {
+      redisMock.mget.mockResolvedValueOnce([null, false, true]);
+      jest
+        .spyOn(service as any, 'isHolidayToday')
+        .mockResolvedValue(false as never);
+
+      const result = await service.canFetchLiveBulk(['luzu', 'olga']);
+
+      expect(result.get('luzu')).toBe(true); // hereda el global
+      expect(result.get('olga')).toBe(false); // override por canal
+    });
+
+    it('batches holiday overrides only for enabled channels', async () => {
+      redisMock.mget
+        .mockResolvedValueOnce([true, false, true]) // fetch_enabled
+        .mockResolvedValueOnce([false]); // holiday override, sólo para luzu
+      jest
+        .spyOn(service as any, 'isHolidayToday')
+        .mockResolvedValue(true as never);
+
+      const result = await service.canFetchLiveBulk(['luzu', 'olga']);
+
+      expect(redisMock.mget).toHaveBeenNthCalledWith(2, [
+        `${HO}youtube.fetch_override_holiday.luzu`,
+      ]);
+      expect(result.get('luzu')).toBe(false); // deshabilitado en feriado
+      expect(result.get('olga')).toBe(false); // fetch_enabled false
+    });
+
+    it('delegates to canFetchLive on a cache miss to preserve semantics', async () => {
+      redisMock.mget.mockResolvedValueOnce([null, null]); // luzu + global sin cachear
+      const single = jest
+        .spyOn(service, 'canFetchLive')
+        .mockResolvedValue(true);
+
+      const result = await service.canFetchLiveBulk(['luzu']);
+
+      expect(single).toHaveBeenCalledWith('luzu');
+      expect(result.get('luzu')).toBe(true);
+    });
+
+    it('deduplicates repeated handles', async () => {
+      redisMock.mget.mockResolvedValueOnce([true, true]);
+      jest
+        .spyOn(service as any, 'isHolidayToday')
+        .mockResolvedValue(false as never);
+
+      const result = await service.canFetchLiveBulk(['luzu', 'luzu', 'luzu']);
+
+      expect(redisMock.mget).toHaveBeenCalledWith([
+        `${FE}youtube.fetch_enabled.luzu`,
+        `${FE}youtube.fetch_enabled`,
+      ]);
+      expect(result.size).toBe(1);
+      expect(result.get('luzu')).toBe(true);
     });
   });
 });

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -187,7 +187,7 @@ export class ConfigService {
     // When holiday custom dates change: invalidate holiday cache + revalidate frontend
     if (key === 'holiday.custom_dates') {
       await this.redisService.del(this.HOLIDAY_CACHE_KEY);
-      this.notifyUtil.notifyAndRevalidate({
+      await this.notifyUtil.notifyAndRevalidate({
         eventType: 'config.updated',
         entity: 'config',
         entityId: key,

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -266,45 +266,135 @@ export class ConfigService {
     return value;
   }
 
+  /**
+   * Versión bulk de canFetchLive: batchea las lecturas de Redis con mget
+   * para evitar N+1 cuando hay que evaluar muchos handles a la vez.
+   *
+   * La semántica es idéntica a canFetchLive: ante cualquier cache miss se
+   * delega en canFetchLive(handle), que resuelve contra la DB y calienta
+   * el cache exactamente igual que antes.
+   */
+  async canFetchLiveBulk(handles: string[]): Promise<Map<string, boolean>> {
+    const result = new Map<string, boolean>();
+    if (!handles || handles.length === 0) return result;
+
+    const uniqueHandles = Array.from(new Set(handles));
+
+    await this.ensureCacheSeeded();
+
+    // 1) Batch de youtube.fetch_enabled (por canal + global al final)
+    const fetchEnabledKeys = uniqueHandles.map(
+      (h) => `${this.FETCH_ENABLED_PREFIX}youtube.fetch_enabled.${h}`,
+    );
+    fetchEnabledKeys.push(`${this.FETCH_ENABLED_PREFIX}youtube.fetch_enabled`);
+
+    const fetchEnabledResults =
+      await this.redisService.mget<boolean>(fetchEnabledKeys);
+    const globalFetchEnabled = fetchEnabledResults[uniqueHandles.length];
+
+    // Handles que no se pudieron resolver desde cache: se resuelven de a uno
+    const needsFallback: string[] = [];
+    // Handles habilitados según cache; sólo estos siguen a la lógica de feriado
+    const enabledHandles: string[] = [];
+
+    for (let i = 0; i < uniqueHandles.length; i++) {
+      const handle = uniqueHandles[i];
+      const perChannel = fetchEnabledResults[i];
+      // Misma precedencia que isYoutubeFetchEnabledFor: por canal -> global -> DB
+      const enabled = perChannel !== null ? perChannel : globalFetchEnabled;
+
+      if (enabled === null) {
+        needsFallback.push(handle);
+      } else if (!enabled) {
+        result.set(handle, false);
+      } else {
+        enabledHandles.push(handle);
+      }
+    }
+
+    if (enabledHandles.length > 0) {
+      const isHoliday = await this.isHolidayToday();
+
+      if (!isHoliday) {
+        for (const handle of enabledHandles) {
+          result.set(handle, true);
+        }
+      } else {
+        // 2) Batch de overrides de feriado
+        const overrideKeys = enabledHandles.map(
+          (h) =>
+            `${this.HOLIDAY_OVERRIDE_PREFIX}youtube.fetch_override_holiday.${h}`,
+        );
+        const overrideResults =
+          await this.redisService.mget<boolean>(overrideKeys);
+
+        for (let i = 0; i < enabledHandles.length; i++) {
+          const handle = enabledHandles[i];
+          const override = overrideResults[i];
+          if (override === null) {
+            needsFallback.push(handle);
+          } else {
+            result.set(handle, override);
+          }
+        }
+      }
+    }
+
+    // 3) Cache misses: camino original, uno por uno (calienta el cache)
+    for (const handle of needsFallback) {
+      result.set(handle, await this.canFetchLive(handle));
+    }
+
+    return result;
+  }
+
+  /**
+   * Resuelve si hoy es feriado (cacheado hasta fin de día, hora Argentina).
+   * Extraído de canFetchLive para poder reutilizarlo desde canFetchLiveBulk.
+   */
+  private async isHolidayToday(): Promise<boolean> {
+    const today = TimezoneUtil.currentDateString(); // YYYY-MM-DD in Argentina time
+
+    const cachedHoliday = await this.redisService.get<{
+      date: string;
+      isHoliday: boolean;
+    }>(this.HOLIDAY_CACHE_KEY);
+
+    if (cachedHoliday && cachedHoliday.date === today) {
+      return cachedHoliday.isHoliday;
+    }
+
+    // Check date-holidays library
+    const argentinaDate = TimezoneUtil.now().toDate();
+    let isHoliday = !!this.hd.isHoliday(argentinaDate);
+
+    // Also check custom dates config (bridge days / "días no laborables")
+    if (!isHoliday) {
+      const customDatesRaw = await this.get('holiday.custom_dates');
+      if (customDatesRaw) {
+        const customDates = customDatesRaw.split(',').map((d) => d.trim());
+        isHoliday = customDates.includes(today);
+      }
+    }
+
+    // Cache until end of day (Argentina time)
+    const ttl = TimezoneUtil.ttlUntilEndOfDay();
+    await this.redisService.set(
+      this.HOLIDAY_CACHE_KEY,
+      { date: today, isHoliday },
+      ttl,
+    );
+
+    return isHoliday;
+  }
+
   async canFetchLive(handle: string): Promise<boolean> {
     // Check if fetch is enabled
     const enabled = await this.isYoutubeFetchEnabledFor(handle);
     if (!enabled) return false;
 
     // Check if today is a holiday (cached daily) - using Argentina/Buenos Aires timezone
-    const today = TimezoneUtil.currentDateString(); // YYYY-MM-DD in Argentina time
-
-    // Check Redis for holiday status
-    const cachedHoliday = await this.redisService.get<{
-      date: string;
-      isHoliday: boolean;
-    }>(this.HOLIDAY_CACHE_KEY);
-
-    let isHoliday: boolean;
-    if (!cachedHoliday || cachedHoliday.date !== today) {
-      // Check date-holidays library
-      const argentinaDate = TimezoneUtil.now().toDate();
-      isHoliday = !!this.hd.isHoliday(argentinaDate);
-
-      // Also check custom dates config (bridge days / "días no laborables")
-      if (!isHoliday) {
-        const customDatesRaw = await this.get('holiday.custom_dates');
-        if (customDatesRaw) {
-          const customDates = customDatesRaw.split(',').map((d) => d.trim());
-          isHoliday = customDates.includes(today);
-        }
-      }
-
-      // Cache until end of day (Argentina time)
-      const ttl = TimezoneUtil.ttlUntilEndOfDay();
-      await this.redisService.set(
-        this.HOLIDAY_CACHE_KEY,
-        { date: today, isHoliday },
-        ttl,
-      );
-    } else {
-      isHoliday = cachedHoliday.isHoliday;
-    }
+    const isHoliday = await this.isHolidayToday();
 
     if (!isHoliday) {
       return true; // Not a holiday, can fetch

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -15,7 +15,7 @@ import { Streamer } from './streamers/streamers.entity';
 import { Category } from './categories/categories.entity';
 import { Banner } from './banners/banners.entity';
 
-const isProduction = process.env.NODE_ENV === 'production';
+const _isProduction = process.env.NODE_ENV === 'production';
 
 export const AppDataSource = new DataSource({
   type: 'postgres',

--- a/src/interceptors/performance.interceptor.spec.ts
+++ b/src/interceptors/performance.interceptor.spec.ts
@@ -1,8 +1,8 @@
 import { PerformanceInterceptor } from './performance.interceptor';
 import { SentryService } from '../sentry/sentry.service';
 import { ExecutionContext, CallHandler } from '@nestjs/common';
-import { of, throwError, timer } from 'rxjs';
-import { map, delay } from 'rxjs/operators';
+import { of, throwError } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 describe('PerformanceInterceptor', () => {
   let interceptor: PerformanceInterceptor;

--- a/src/interceptors/performance.interceptor.ts
+++ b/src/interceptors/performance.interceptor.ts
@@ -14,7 +14,7 @@ export class PerformanceInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request = context.switchToHttp().getRequest();
-    const response = context.switchToHttp().getResponse();
+    const _response = context.switchToHttp().getResponse();
     const startTime = Date.now();
 
     // Generate unique request ID for tracing
@@ -46,7 +46,7 @@ export class PerformanceInterceptor implements NestInterceptor {
     });
 
     return next.handle().pipe(
-      tap((data) => {
+      tap((_data) => {
         const responseTime = Date.now() - startTime;
 
         // Log performance metrics with request ID

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,4 +40,4 @@ async function bootstrap() {
   await app.listen(port, '0.0.0.0');
   console.log(`🚀 Application is running on port ${port}`);
 }
-bootstrap();
+void bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  const configService = app.get(ConfigService);
+  const _configService = app.get(ConfigService);
 
   const config = new DocumentBuilder()
     .setTitle('Streaming Guide API')

--- a/src/migrations/1754000000000-BackfillChannelYouTubeConfigs.ts
+++ b/src/migrations/1754000000000-BackfillChannelYouTubeConfigs.ts
@@ -63,7 +63,7 @@ export class BackfillChannelYouTubeConfigs1754000000000
     }
   }
 
-  public async down(queryRunner: QueryRunner): Promise<void> {
+  public async down(_queryRunner: QueryRunner): Promise<void> {
     // This migration only creates missing configs, so the down migration
     // would need to know which configs were created by this migration.
     // Since we can't easily track that, we'll leave the configs in place.

--- a/src/migrations/1783100000000-AddSeenFeaturesToUsers.ts
+++ b/src/migrations/1783100000000-AddSeenFeaturesToUsers.ts
@@ -10,8 +10,6 @@ export class AddSeenFeaturesToUsers1783100000000 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "users" DROP COLUMN "seen_features"`,
-    );
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "seen_features"`);
   }
 }

--- a/src/panelists/dto/create-panelist.dto.spec.ts
+++ b/src/panelists/dto/create-panelist.dto.spec.ts
@@ -32,7 +32,7 @@ describe('CreatePanelistDto', () => {
 
   it('should fail if name is not a string', async () => {
     const dto = new CreatePanelistDto();
-    // @ts-expect-error
+    // @ts-expect-error - asignacion invalida a proposito para probar la validacion
     dto.name = 123;
     dto.bio = 'Bio válida';
 
@@ -44,7 +44,7 @@ describe('CreatePanelistDto', () => {
   it('should fail if bio is not a string', async () => {
     const dto = new CreatePanelistDto();
     dto.name = 'Nombre válido';
-    // @ts-expect-error
+    // @ts-expect-error - asignacion invalida a proposito para probar la validacion
     dto.bio = 123;
 
     const errors = await validate(dto);

--- a/src/panelists/panelists.service.spec.ts
+++ b/src/panelists/panelists.service.spec.ts
@@ -4,7 +4,7 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Panelist } from './panelists.entity';
 import { Program } from '../programs/programs.entity';
 import { CreatePanelistDto } from './dto/create-panelist.dto';
-import { UpdatePanelistDto } from './dto/update-panelist.dto';
+import {} from './dto/update-panelist.dto';
 import { RedisService } from '../redis/redis.service';
 import { NotFoundException } from '@nestjs/common';
 import { NotifyAndRevalidateUtil } from '../utils/notify-and-revalidate.util';

--- a/src/panelists/panelists.service.spec.ts
+++ b/src/panelists/panelists.service.spec.ts
@@ -4,7 +4,6 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { Panelist } from './panelists.entity';
 import { Program } from '../programs/programs.entity';
 import { CreatePanelistDto } from './dto/create-panelist.dto';
-import {} from './dto/update-panelist.dto';
 import { RedisService } from '../redis/redis.service';
 import { NotFoundException } from '@nestjs/common';
 import { NotifyAndRevalidateUtil } from '../utils/notify-and-revalidate.util';

--- a/src/panelists/panelists.service.ts
+++ b/src/panelists/panelists.service.ts
@@ -5,7 +5,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Panelist } from './panelists.entity';
 import { CreatePanelistDto } from './dto/create-panelist.dto';
 import { UpdatePanelistDto } from './dto/update-panelist.dto';
@@ -63,7 +63,7 @@ export class PanelistsService {
   }
 
   async findOne(id: string | number): Promise<Panelist> {
-    const startTime = Date.now();
+    const _startTime = Date.now();
     const cacheKey = `panelists:${id}`;
     console.log(`[Cache] Attempting to get panelist ${id} from cache`);
 

--- a/src/programs/programs.controller.spec.ts
+++ b/src/programs/programs.controller.spec.ts
@@ -3,7 +3,6 @@ import { ProgramsController } from './programs.controller';
 import { ProgramsService } from './programs.service';
 import { SubscriptionService } from '../users/subscription.service';
 import { CreateProgramDto } from './dto/create-program.dto';
-import {} from './programs.entity';
 
 describe('ProgramsController', () => {
   let controller: ProgramsController;

--- a/src/programs/programs.controller.spec.ts
+++ b/src/programs/programs.controller.spec.ts
@@ -3,11 +3,11 @@ import { ProgramsController } from './programs.controller';
 import { ProgramsService } from './programs.service';
 import { SubscriptionService } from '../users/subscription.service';
 import { CreateProgramDto } from './dto/create-program.dto';
-import { Program } from './programs.entity';
+import {} from './programs.entity';
 
 describe('ProgramsController', () => {
   let controller: ProgramsController;
-  let service: ProgramsService;
+  let _service: ProgramsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -45,7 +45,7 @@ describe('ProgramsController', () => {
     }).compile();
 
     controller = module.get<ProgramsController>(ProgramsController);
-    service = module.get<ProgramsService>(ProgramsService);
+    _service = module.get<ProgramsService>(ProgramsService);
   });
 
   it('should be defined', () => {

--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -124,6 +124,7 @@ describe('ProgramsService', () => {
 
     panelistRepository = {
       findOne: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
     };
 
     channelRepository = {

--- a/src/programs/programs.service.spec.ts
+++ b/src/programs/programs.service.spec.ts
@@ -32,7 +32,7 @@ describe('ProgramsService', () => {
     is_visible: true,
   };
 
-  const mockProgram = {
+  const _mockProgram = {
     id: 1,
     name: 'Test Program',
     description: 'Test Description',

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -137,12 +137,10 @@ export class ProgramsService {
 
     // Assign panelists to all created programs if provided
     if (dto.panelist_ids && dto.panelist_ids.length > 0) {
-      const panelists = await Promise.all(
-        dto.panelist_ids.map((pid) =>
-          this.panelistsRepository.findOne({ where: { id: pid } }),
-        ),
-      );
-      const validPanelists = panelists.filter(Boolean) as Panelist[];
+      // Batch fetch: evita N+1 (un findOne por panelista)
+      const validPanelists = await this.panelistsRepository.find({
+        where: { id: In(dto.panelist_ids) },
+      });
       if (validPanelists.length > 0) {
         for (const program of savedPrograms) {
           program.panelists = validPanelists;

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -5,7 +5,7 @@ import {
   forwardRef,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { FindOneOptions, In, Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import { Program } from './programs.entity';
 import { CreateProgramDto } from './dto/create-program.dto';

--- a/src/proposed-changes/proposed-changes.service.ts
+++ b/src/proposed-changes/proposed-changes.service.ts
@@ -10,7 +10,7 @@ interface CreateProposedChangeInput {
   action: 'create' | 'update' | 'delete';
   channelName: string;
   programName: string;
-  before: any | null;
+  before: any;
   after: any;
 }
 

--- a/src/push/push.controller.spec.ts
+++ b/src/push/push.controller.spec.ts
@@ -5,7 +5,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 
 describe('PushController', () => {
   let controller: PushController;
-  let pushService: PushService;
+  let _pushService: PushService;
 
   const mockPushService = {
     create: jest.fn(),
@@ -33,7 +33,7 @@ describe('PushController', () => {
     }).compile();
 
     controller = module.get<PushController>(PushController);
-    pushService = module.get<PushService>(PushService);
+    _pushService = module.get<PushService>(PushService);
   });
 
   afterEach(() => {

--- a/src/push/push.scheduler.spec.ts
+++ b/src/push/push.scheduler.spec.ts
@@ -1,14 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
-import { Logger } from '@nestjs/common';
+import {} from '@nestjs/common';
 import { PushScheduler } from './push.scheduler';
 import { PushService } from './push.service';
 import { EmailService } from '../email/email.service';
 import { Schedule } from '../schedules/schedules.entity';
 import { UserSubscription } from '../users/user-subscription.entity';
 import { PushSubscriptionEntity } from './push-subscription.entity';
-import * as dayjs from 'dayjs';
 import { ConfigService } from '../config/config.service';
 import { SchedulesService } from '../schedules/schedules.service';
 
@@ -45,11 +44,11 @@ jest.mock('dayjs', () => {
 describe('PushScheduler', () => {
   let module: TestingModule;
   let scheduler: PushScheduler;
-  let pushService: PushService;
-  let emailService: EmailService;
-  let scheduleRepository: Repository<Schedule>;
-  let userSubscriptionRepository: Repository<UserSubscription>;
-  let pushSubscriptionRepository: Repository<PushSubscriptionEntity>;
+  let _pushService: PushService;
+  let _emailService: EmailService;
+  let _scheduleRepository: Repository<Schedule>;
+  let _userSubscriptionRepository: Repository<UserSubscription>;
+  let _pushSubscriptionRepository: Repository<PushSubscriptionEntity>;
 
   const mockChannel = {
     id: 1,
@@ -168,17 +167,17 @@ describe('PushScheduler', () => {
     }).compile();
 
     scheduler = module.get<PushScheduler>(PushScheduler);
-    pushService = module.get<PushService>(PushService);
-    emailService = module.get<EmailService>(EmailService);
-    scheduleRepository = module.get<Repository<Schedule>>(
+    _pushService = module.get<PushService>(PushService);
+    _emailService = module.get<EmailService>(EmailService);
+    _scheduleRepository = module.get<Repository<Schedule>>(
       getRepositoryToken(Schedule),
     );
-    userSubscriptionRepository = module.get<Repository<UserSubscription>>(
+    _userSubscriptionRepository = module.get<Repository<UserSubscription>>(
       getRepositoryToken(UserSubscription),
     );
-    pushSubscriptionRepository = module.get<Repository<PushSubscriptionEntity>>(
-      getRepositoryToken(PushSubscriptionEntity),
-    );
+    _pushSubscriptionRepository = module.get<
+      Repository<PushSubscriptionEntity>
+    >(getRepositoryToken(PushSubscriptionEntity));
 
     // Mock logger methods
     jest.spyOn(scheduler['logger'], 'log').mockImplementation();

--- a/src/push/push.scheduler.spec.ts
+++ b/src/push/push.scheduler.spec.ts
@@ -151,6 +151,11 @@ describe('PushScheduler', () => {
           provide: ConfigService,
           useValue: {
             canFetchLive: jest.fn().mockResolvedValue(true),
+            canFetchLiveBulk: jest
+              .fn()
+              .mockImplementation((handles: string[] = []) =>
+                Promise.resolve(new Map(handles.map((h) => [h, true]))),
+              ),
           },
         },
         {

--- a/src/push/push.scheduler.spec.ts
+++ b/src/push/push.scheduler.spec.ts
@@ -1,7 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, In } from 'typeorm';
-import {} from '@nestjs/common';
 import { PushScheduler } from './push.scheduler';
 import { PushService } from './push.service';
 import { EmailService } from '../email/email.service';

--- a/src/push/push.scheduler.ts
+++ b/src/push/push.scheduler.ts
@@ -150,12 +150,8 @@ export class PushScheduler {
           .filter((h): h is string => !!h),
       ),
     );
-    const fetchableMap = new Map<string, boolean>();
-    await Promise.all(
-      uniqueChannelHandles.map(async (handle) => {
-        fetchableMap.set(handle, await this.configService.canFetchLive(handle));
-      }),
-    );
+    const fetchableMap =
+      await this.configService.canFetchLiveBulk(uniqueChannelHandles);
 
     // 6) Enviar notificaciones por programa + usuario (concurrently)
     const pushPromises: Promise<void>[] = [];

--- a/src/push/push.service.spec.ts
+++ b/src/push/push.service.spec.ts
@@ -14,8 +14,8 @@ const mockWebPush = webpush as jest.Mocked<typeof webpush>;
 
 describe('PushService', () => {
   let service: PushService;
-  let pushSubscriptionRepository: Repository<PushSubscriptionEntity>;
-  let deviceRepository: Repository<Device>;
+  let _pushSubscriptionRepository: Repository<PushSubscriptionEntity>;
+  let _deviceRepository: Repository<Device>;
 
   const mockDevice: Partial<Device> = {
     id: 'device-uuid',
@@ -78,10 +78,10 @@ describe('PushService', () => {
     }).compile();
 
     service = module.get<PushService>(PushService);
-    pushSubscriptionRepository = module.get<Repository<PushSubscriptionEntity>>(
-      getRepositoryToken(PushSubscriptionEntity),
-    );
-    deviceRepository = module.get<Repository<Device>>(
+    _pushSubscriptionRepository = module.get<
+      Repository<PushSubscriptionEntity>
+    >(getRepositoryToken(PushSubscriptionEntity));
+    _deviceRepository = module.get<Repository<Device>>(
       getRepositoryToken(Device),
     );
 

--- a/src/push/push.service.spec.ts
+++ b/src/push/push.service.spec.ts
@@ -280,7 +280,9 @@ describe('PushService', () => {
     const allowSubscriptionCreation = () => {
       const saveable = { ...ownedDevice } as Device;
       mockDeviceRepository.findOne.mockResolvedValue(saveable);
-      (mockDeviceRepository as any).save = jest.fn().mockResolvedValue(saveable);
+      (mockDeviceRepository as any).save = jest
+        .fn()
+        .mockResolvedValue(saveable);
       mockPushSubscriptionRepository.findOne.mockResolvedValue(null);
       mockPushSubscriptionRepository.create.mockReturnValue(
         mockPushSubscription,

--- a/src/push/push.service.ts
+++ b/src/push/push.service.ts
@@ -203,8 +203,7 @@ export class PushService {
       (requesterUserId === null ||
         String(device.user.id) !== String(requesterUserId))
     ) {
-      const enforcing =
-        process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP === 'true';
+      const enforcing = process.env.PUSH_ENFORCE_DEVICE_OWNERSHIP === 'true';
       console.warn(
         `🚫 [PushService] FCM subscribe ownership mismatch: deviceId=${deviceId}, ownedByUser=${device.user.id}, requester=${requesterUserId ?? 'anonymous'}, appVersion=${appVersion ?? 'unknown'}, enforcing=${enforcing}`,
       );

--- a/src/redis/redis.service.spec.ts
+++ b/src/redis/redis.service.spec.ts
@@ -102,9 +102,10 @@ describe('RedisService', () => {
 
   describe('delByPattern', () => {
     it('deletes keys matching pattern', async () => {
-      const onHandlers: Record<string, Function> = {};
+      type StreamHandler = (...args: any[]) => void;
+      const onHandlers: Record<string, StreamHandler> = {};
       const fakeStream = {
-        on: (event: string, handler: Function) => {
+        on: (event: string, handler: StreamHandler) => {
           onHandlers[event] = handler;
         },
       };

--- a/src/redis/redis.service.spec.ts
+++ b/src/redis/redis.service.spec.ts
@@ -13,7 +13,6 @@ jest.mock('ioredis', () => ({
 }));
 
 import { RedisService } from './redis.service';
-import Redis from 'ioredis';
 import { SentryService } from '../sentry/sentry.service';
 
 describe('RedisService', () => {

--- a/src/schedules/schedules-logging.spec.ts
+++ b/src/schedules/schedules-logging.spec.ts
@@ -13,8 +13,8 @@ import { SentryService } from '../sentry/sentry.service';
 
 describe('SchedulesService Logging Improvements', () => {
   let service: SchedulesService;
-  let schedulesRepository: Repository<Schedule>;
-  let redisService: RedisService;
+  let _schedulesRepository: Repository<Schedule>;
+  let _redisService: RedisService;
 
   const mockSchedule: Schedule = {
     id: 1,
@@ -130,10 +130,10 @@ describe('SchedulesService Logging Improvements', () => {
     }).compile();
 
     service = module.get<SchedulesService>(SchedulesService);
-    schedulesRepository = module.get<Repository<Schedule>>(
+    _schedulesRepository = module.get<Repository<Schedule>>(
       getRepositoryToken(Schedule),
     );
-    redisService = module.get<RedisService>(RedisService);
+    _redisService = module.get<RedisService>(RedisService);
   });
 
   afterEach(() => {

--- a/src/schedules/schedules.service.spec.ts
+++ b/src/schedules/schedules.service.spec.ts
@@ -53,22 +53,22 @@ jest.mock('dayjs', () => {
         return parseInt(m);
       },
       tz: () => mockDayjs(),
-      startOf: (unit: string) => {
+      startOf: (_unit: string) => {
         // Return a mock object with the add method that can be chained
         return {
-          add: (amount: number, unit: string) => {
+          add: (_amount: number, _unit: string) => {
             // Return a mock object with the diff method and more add methods
             return {
-              add: (amount: number, unit: string) => {
+              add: (_amount: number, _unit: string) => {
                 // Return a mock object with the diff method
                 return {
-                  diff: (date: any, unit: string) => {
+                  diff: (_date: any, _unit: string) => {
                     // Return a reasonable TTL value for testing
                     return 3600; // 1 hour in seconds
                   },
                 };
               },
-              diff: (date: any, unit: string) => {
+              diff: (_date: any, _unit: string) => {
                 // Return a reasonable TTL value for testing
                 return 3600; // 1 hour in seconds
               },
@@ -88,12 +88,12 @@ jest.mock('dayjs', () => {
         ];
         return days.indexOf(currentDay);
       },
-      add: (amount: number, unit: string) => makeChainable(),
-      diff: (date: any, unit: string) => {
+      add: (_amount: number, _unit: string) => makeChainable(),
+      diff: (_date: any, _unit: string) => {
         // Return a reasonable TTL value for testing
         return 3600; // 1 hour in seconds
       },
-      endOf: (unit: string) => makeChainable(),
+      endOf: (_unit: string) => makeChainable(),
     };
   };
 

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -289,7 +289,7 @@ export class SchedulesService {
       this.isWarmingCache = false;
       if (this.pendingWarm) {
         this.pendingWarm = false;
-        setImmediate(() => this.warmSchedulesCache());
+        setImmediate(() => void this.warmSchedulesCache());
       }
     }
   }
@@ -305,7 +305,7 @@ export class SchedulesService {
     }
     this.warmCacheTimer = setTimeout(() => {
       this.warmCacheTimer = null;
-      this.warmSchedulesCache();
+      void this.warmSchedulesCache();
     }, SchedulesService.WARM_CACHE_DEBOUNCE_MS);
   }
 
@@ -358,7 +358,7 @@ export class SchedulesService {
 
       if (liveChannelIds.length > 0) {
         // Trigger async background fetch (non-blocking)
-        setImmediate(async () => {
+        setImmediate(() => {
           try {
             // Background live status will be handled by OptimizedSchedulesService
           } catch (error) {
@@ -731,7 +731,7 @@ export class SchedulesService {
   private findBestMatchingStream(
     programName: string,
     availableStreams: any[],
-  ): any | null {
+  ): any {
     if (availableStreams.length === 0) return null;
 
     // Simple title similarity matching (Jaccard similarity)

--- a/src/schedules/schedules.service.ts
+++ b/src/schedules/schedules.service.ts
@@ -1,11 +1,6 @@
 import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import {
-  Repository,
-  FindOneOptions,
-  FindManyOptions,
-  FindOptionsWhere,
-} from 'typeorm';
+import { Repository, FindOneOptions } from 'typeorm';
 import { Schedule } from './schedules.entity';
 import { Program } from '../programs/programs.entity';
 import {
@@ -14,7 +9,6 @@ import {
 } from './dto/create-schedule.dto';
 import { UpdateScheduleDto } from './dto/update-schedule.dto';
 import { YoutubeLiveService } from '../youtube/youtube-live.service';
-import { LiveStream } from '../youtube/interfaces/live-stream.interface';
 import { RedisService } from '../redis/redis.service';
 import { WeeklyOverridesService } from './weekly-overrides.service';
 import { SentryService } from '../sentry/sentry.service';
@@ -81,10 +75,10 @@ export class SchedulesService {
     const {
       dayOfWeek,
       relations = ['program', 'program.channel', 'program.panelists'],
-      select,
+      select: _select,
       skipCache = false,
-      applyOverrides = true,
-      liveStatus = false,
+      applyOverrides: _applyOverrides = true,
+      liveStatus: _liveStatus = false,
       raw = false,
     } = options;
 
@@ -169,7 +163,7 @@ export class SchedulesService {
    */
   private async fetchSchedulesFromDatabase(
     dayOfWeek?: string,
-    relations?: string[],
+    _relations?: string[],
   ): Promise<Schedule[]> {
     const dbStart = Date.now();
 
@@ -313,7 +307,7 @@ export class SchedulesService {
     schedules: Schedule[],
     liveStatus: boolean = false,
   ): Promise<any[]> {
-    const now = TimezoneUtil.now();
+    const _now = TimezoneUtil.now();
     const currentNum = TimezoneUtil.currentTimeInMinutes();
     const currentDay = TimezoneUtil.currentDayOfWeek();
     const previousDay = TimezoneUtil.previousDayOfWeek();
@@ -566,9 +560,9 @@ export class SchedulesService {
     }
 
     // Count live programs for this channel
-    const liveProgramCount = liveSchedules.length;
+    const _liveProgramCount = liveSchedules.length;
     // Total streams available from YouTube API
-    const totalStreamsAvailable = channelStreamCount;
+    const _totalStreamsAvailable = channelStreamCount;
 
     // Distribute streams to live schedules using title matching
     const usedStreams = new Set<string>();

--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -33,14 +33,21 @@ export class WeeklyOverridesController {
   ) {}
 
   @Post('bulk')
-  @ApiOperation({ summary: 'Create a special program override for multiple channels at once' })
-  @ApiResponse({ status: 201, description: 'Bulk overrides created successfully' })
+  @ApiOperation({
+    summary: 'Create a special program override for multiple channels at once',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Bulk overrides created successfully',
+  })
   async createBulkOverride(@Body() dto: BulkWeeklyOverrideDto) {
     return this.weeklyOverridesService.createBulk(dto);
   }
 
   @Post('resolve-conflicts')
-  @ApiOperation({ summary: 'Resolve schedule conflicts after a linked-program override' })
+  @ApiOperation({
+    summary: 'Resolve schedule conflicts after a linked-program override',
+  })
   @ApiResponse({ status: 201, description: 'Conflicts resolved successfully' })
   async resolveConflicts(@Body() dto: ResolveConflictsDto) {
     return this.weeklyOverridesService.resolveConflicts(dto);

--- a/src/schedules/weekly-overrides.controller.ts
+++ b/src/schedules/weekly-overrides.controller.ts
@@ -6,7 +6,6 @@ import {
   Body,
   Param,
   UseGuards,
-  HttpStatus,
   Put,
 } from '@nestjs/common';
 import {

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1185,7 +1185,7 @@ export class WeeklyOverridesService {
           case 'cancel':
             // Skip all schedules for this program
             continue;
-          case 'time_change':
+          case 'time_change': {
             // Apply time change to all schedules of this program
             const modifiedSchedule1 = {
               ...schedule,
@@ -1208,7 +1208,8 @@ export class WeeklyOverridesService {
 
             modifiedSchedules.push(modifiedSchedule1);
             break;
-          case 'reschedule':
+          }
+          case 'reschedule': {
             // Apply reschedule to all schedules of this program
             const modifiedSchedule2 = {
               ...schedule,
@@ -1232,6 +1233,7 @@ export class WeeklyOverridesService {
 
             modifiedSchedules.push(modifiedSchedule2);
             break;
+          }
           default:
             modifiedSchedules.push(schedule);
         }
@@ -1251,7 +1253,7 @@ export class WeeklyOverridesService {
           // Skip cancelled programs
           continue;
 
-        case 'time_change':
+        case 'time_change': {
           const modifiedSchedule3 = {
             ...schedule,
             start_time: scheduleOverride.newStartTime || schedule.start_time,
@@ -1273,8 +1275,9 @@ export class WeeklyOverridesService {
 
           modifiedSchedules.push(modifiedSchedule3);
           break;
+        }
 
-        case 'reschedule':
+        case 'reschedule': {
           const modifiedSchedule4 = {
             ...schedule,
             start_time: scheduleOverride.newStartTime || schedule.start_time,
@@ -1297,6 +1300,7 @@ export class WeeklyOverridesService {
 
           modifiedSchedules.push(modifiedSchedule4);
           break;
+        }
 
         default:
           modifiedSchedules.push(schedule);

--- a/src/schedules/weekly-overrides.service.ts
+++ b/src/schedules/weekly-overrides.service.ts
@@ -1382,7 +1382,7 @@ export class WeeklyOverridesService {
    */
   async cleanupExpiredOverrides(): Promise<number> {
     const pattern = 'weekly_override:*';
-    const overrides: WeeklyOverride[] = [];
+    const _overrides: WeeklyOverride[] = [];
 
     // Use Redis SCAN to find all weekly override keys
     const stream = (this.redisService as any).client.scanStream({

--- a/src/schedules/weekly-schedule-manager.service.ts
+++ b/src/schedules/weekly-schedule-manager.service.ts
@@ -1,8 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import { WeeklyOverridesService } from './weekly-overrides.service';
 import { RedisService } from '../redis/redis.service';
-import * as dayjs from 'dayjs';
 
 @Injectable()
 export class WeeklyScheduleManagerService {

--- a/src/sentry/sentry.service.spec.ts
+++ b/src/sentry/sentry.service.spec.ts
@@ -17,7 +17,7 @@ jest.mock('@sentry/node', () => ({
 }));
 
 describe('SentryService', () => {
-  let service: SentryService;
+  let _service: SentryService;
   let mockScope: any;
 
   beforeEach(() => {
@@ -28,7 +28,7 @@ describe('SentryService', () => {
     (Sentry.withScope as jest.Mock).mockImplementation((callback) =>
       callback(mockScope),
     );
-    service = new SentryService();
+    _service = new SentryService();
   });
 
   afterEach(() => {

--- a/src/services/connection-pool-monitor.service.ts
+++ b/src/services/connection-pool-monitor.service.ts
@@ -8,7 +8,7 @@ export class ConnectionPoolMonitorService implements OnModuleInit {
 
   async onModuleInit() {
     // Log initial pool status
-    this.logPoolStatus();
+    await this.logPoolStatus();
   }
 
   /**

--- a/src/statistics/comprehensive-report.controller.ts
+++ b/src/statistics/comprehensive-report.controller.ts
@@ -10,15 +10,12 @@ import {
 import { Response } from 'express';
 import { ComprehensiveReportService } from './comprehensive-report.service';
 import {
-  BaseReportDto,
   ChannelReportDto,
   PeriodicReportDto,
   BatchReportDto,
-  AutomaticReportDto,
   ReportPeriod,
   ReportFormat,
   ReportAction,
-  ReportType,
 } from './dto/report.dto';
 
 @ApiTags('comprehensive-reports')

--- a/src/statistics/comprehensive-report.service.ts
+++ b/src/statistics/comprehensive-report.service.ts
@@ -49,7 +49,7 @@ export class ComprehensiveReportService {
       throw new Error('Channel not found');
     }
 
-    const reportParams = {
+    const _reportParams = {
       type: ReportType.COMPREHENSIVE_CHANNEL_SUMMARY,
       format,
       from,

--- a/src/statistics/dto/report.dto.ts
+++ b/src/statistics/dto/report.dto.ts
@@ -5,7 +5,6 @@ import {
   IsNumber,
   IsArray,
   ValidateNested,
-  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 

--- a/src/statistics/statistics.controller.spec.ts
+++ b/src/statistics/statistics.controller.spec.ts
@@ -3,7 +3,7 @@ import { StatisticsController } from './statistics.controller';
 import { StatisticsService } from './statistics.service';
 import { ReportsProxyService } from './reports-proxy.service';
 import { EmailService } from '../email/email.service';
-import { NotFoundException } from '@nestjs/common';
+import {} from '@nestjs/common';
 import { Response } from 'express';
 
 describe('StatisticsController', () => {

--- a/src/statistics/statistics.controller.spec.ts
+++ b/src/statistics/statistics.controller.spec.ts
@@ -3,7 +3,6 @@ import { StatisticsController } from './statistics.controller';
 import { StatisticsService } from './statistics.service';
 import { ReportsProxyService } from './reports-proxy.service';
 import { EmailService } from '../email/email.service';
-import {} from '@nestjs/common';
 import { Response } from 'express';
 
 describe('StatisticsController', () => {

--- a/src/statistics/statistics.controller.ts
+++ b/src/statistics/statistics.controller.ts
@@ -14,9 +14,7 @@ import { EmailService } from '../email/email.service';
 import { Response } from 'express';
 import { UnifiedReportDto } from './dto/unified-report.dto';
 import {
-  ChannelReportDto,
   ChannelReportEmailDto,
-  PeriodicReportDto,
   PeriodicReportEmailDto,
 } from './dto/channel-report.dto';
 

--- a/src/statistics/statistics.service.spec.ts
+++ b/src/statistics/statistics.service.spec.ts
@@ -14,9 +14,9 @@ describe('StatisticsService', () => {
   let userRepo: Repository<User>;
   let subscriptionRepo: Repository<UserSubscription>;
   let programRepo: Repository<Program>;
-  let channelRepo: Repository<Channel>;
+  let _channelRepo: Repository<Channel>;
   let reportsProxyService: ReportsProxyService;
-  let emailService: EmailService;
+  let _emailService: EmailService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -63,9 +63,9 @@ describe('StatisticsService', () => {
       getRepositoryToken(UserSubscription),
     );
     programRepo = module.get<Repository<Program>>(getRepositoryToken(Program));
-    channelRepo = module.get<Repository<Channel>>(getRepositoryToken(Channel));
+    _channelRepo = module.get<Repository<Channel>>(getRepositoryToken(Channel));
     reportsProxyService = module.get<ReportsProxyService>(ReportsProxyService);
-    emailService = module.get<EmailService>(EmailService);
+    _emailService = module.get<EmailService>(EmailService);
   });
 
   it('should be defined', () => {

--- a/src/statistics/statistics.service.ts
+++ b/src/statistics/statistics.service.ts
@@ -7,7 +7,6 @@ import { Program } from '../programs/programs.entity';
 import { Channel } from '../channels/channels.entity';
 import { ReportsProxyService } from './reports-proxy.service';
 import { EmailService } from '../email/email.service';
-import * as dayjs from 'dayjs';
 
 export interface UserDemographics {
   totalUsers: number;

--- a/src/streamers/dto/update-streamer.dto.ts
+++ b/src/streamers/dto/update-streamer.dto.ts
@@ -8,10 +8,9 @@ import {
   IsArray,
   IsNumber,
   ValidateNested,
-  IsEnum,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { StreamerServiceDto, StreamingService } from './create-streamer.dto';
+import { StreamerServiceDto } from './create-streamer.dto';
 
 export class UpdateStreamerDto {
   @ApiProperty({ required: false })

--- a/src/streamers/streamer-live-status.service.spec.ts
+++ b/src/streamers/streamer-live-status.service.spec.ts
@@ -7,8 +7,8 @@ import { StreamerLiveStatusCache } from './interfaces/streamer-live-status-cache
 
 describe('StreamerLiveStatusService', () => {
   let service: StreamerLiveStatusService;
-  let redisService: RedisService;
-  let subscriptionService: StreamerSubscriptionService;
+  let _redisService: RedisService;
+  let _subscriptionService: StreamerSubscriptionService;
 
   const mockRedisService = {
     get: jest.fn(),
@@ -52,8 +52,8 @@ describe('StreamerLiveStatusService', () => {
     }).compile();
 
     service = module.get<StreamerLiveStatusService>(StreamerLiveStatusService);
-    redisService = module.get<RedisService>(RedisService);
-    subscriptionService = module.get<StreamerSubscriptionService>(
+    _redisService = module.get<RedisService>(RedisService);
+    _subscriptionService = module.get<StreamerSubscriptionService>(
       StreamerSubscriptionService,
     );
   });

--- a/src/streamers/streamers.controller.spec.ts
+++ b/src/streamers/streamers.controller.spec.ts
@@ -5,7 +5,7 @@ import { SupabaseStorageService } from '../banners/supabase-storage.service';
 import { CreateStreamerDto, StreamingService } from './dto/create-streamer.dto';
 import { UpdateStreamerDto } from './dto/update-streamer.dto';
 import { Streamer } from './streamers.entity';
-import { NotFoundException } from '@nestjs/common';
+import {} from '@nestjs/common';
 
 describe('StreamersController', () => {
   let controller: StreamersController;

--- a/src/streamers/streamers.controller.spec.ts
+++ b/src/streamers/streamers.controller.spec.ts
@@ -5,7 +5,6 @@ import { SupabaseStorageService } from '../banners/supabase-storage.service';
 import { CreateStreamerDto, StreamingService } from './dto/create-streamer.dto';
 import { UpdateStreamerDto } from './dto/update-streamer.dto';
 import { Streamer } from './streamers.entity';
-import {} from '@nestjs/common';
 
 describe('StreamersController', () => {
   let controller: StreamersController;

--- a/src/streamers/utils/generate-service-url.ts
+++ b/src/streamers/utils/generate-service-url.ts
@@ -19,6 +19,6 @@ export function generateServiceUrl(
       // YouTube URLs are more complex (videos, channels, etc.), so we don't auto-generate
       throw new Error('YouTube URLs cannot be auto-generated from username');
     default:
-      throw new Error(`Unknown service: ${service}`);
+      throw new Error(`Unknown service: ${String(service)}`);
   }
 }

--- a/src/users/admin-subscription.controller.ts
+++ b/src/users/admin-subscription.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   Delete,
   UseGuards,
-  ParseIntPipe,
 } from '@nestjs/common';
 import { Roles } from '../auth/roles.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';

--- a/src/users/device.service.spec.ts
+++ b/src/users/device.service.spec.ts
@@ -7,7 +7,7 @@ import { User } from './users.entity';
 
 describe('DeviceService', () => {
   let service: DeviceService;
-  let repository: Repository<Device>;
+  let _repository: Repository<Device>;
 
   const mockUser: User = {
     id: 1,
@@ -64,7 +64,7 @@ describe('DeviceService', () => {
     }).compile();
 
     service = module.get<DeviceService>(DeviceService);
-    repository = module.get<Repository<Device>>(getRepositoryToken(Device));
+    _repository = module.get<Repository<Device>>(getRepositoryToken(Device));
   });
 
   afterEach(() => {

--- a/src/users/subscription.controller.spec.ts
+++ b/src/users/subscription.controller.spec.ts
@@ -4,8 +4,6 @@ import { SubscriptionService } from './subscription.service';
 import { DeviceService } from './device.service';
 import { UsersService } from './users.service';
 
-import {} from '@nestjs/common';
-
 describe('SubscriptionController', () => {
   let controller: SubscriptionController;
   let _subscriptionService: SubscriptionService;

--- a/src/users/subscription.controller.spec.ts
+++ b/src/users/subscription.controller.spec.ts
@@ -4,11 +4,11 @@ import { SubscriptionService } from './subscription.service';
 import { DeviceService } from './device.service';
 import { UsersService } from './users.service';
 
-import { NotFoundException } from '@nestjs/common';
+import {} from '@nestjs/common';
 
 describe('SubscriptionController', () => {
   let controller: SubscriptionController;
-  let subscriptionService: SubscriptionService;
+  let _subscriptionService: SubscriptionService;
 
   const mockUser = {
     id: 1,
@@ -68,7 +68,7 @@ describe('SubscriptionController', () => {
     }).compile();
 
     controller = module.get<SubscriptionController>(SubscriptionController);
-    subscriptionService = module.get<SubscriptionService>(SubscriptionService);
+    _subscriptionService = module.get<SubscriptionService>(SubscriptionService);
   });
 
   afterEach(() => {

--- a/src/users/subscription.service.spec.ts
+++ b/src/users/subscription.service.spec.ts
@@ -6,14 +6,14 @@ import { UserSubscription } from './user-subscription.entity';
 import { Program } from '../programs/programs.entity';
 import { User } from './users.entity';
 import { Channel } from '../channels/channels.entity';
-import { NotFoundException, ConflictException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { Device } from './device.entity';
 import { PushSubscriptionEntity } from '../push/push-subscription.entity';
 
 describe('SubscriptionService', () => {
   let service: SubscriptionService;
-  let userSubscriptionRepository: Repository<UserSubscription>;
-  let programRepository: Repository<Program>;
+  let _userSubscriptionRepository: Repository<UserSubscription>;
+  let _programRepository: Repository<Program>;
 
   const mockUser: User = {
     id: 1,
@@ -121,10 +121,10 @@ describe('SubscriptionService', () => {
     }).compile();
 
     service = module.get<SubscriptionService>(SubscriptionService);
-    userSubscriptionRepository = module.get<Repository<UserSubscription>>(
+    _userSubscriptionRepository = module.get<Repository<UserSubscription>>(
       getRepositoryToken(UserSubscription),
     );
-    programRepository = module.get<Repository<Program>>(
+    _programRepository = module.get<Repository<Program>>(
       getRepositoryToken(Program),
     );
   });

--- a/src/users/subscription.service.ts
+++ b/src/users/subscription.service.ts
@@ -1,8 +1,4 @@
-import {
-  Injectable,
-  NotFoundException,
-  BadRequestException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserSubscription } from './user-subscription.entity';

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -5,7 +5,6 @@ import { AuthService } from '../auth/auth.service';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
-import {} from '../auth/roles.decorator';
 import { OtpService } from '../auth/otp.service';
 
 const mockUser = {

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -5,7 +5,7 @@ import { AuthService } from '../auth/auth.service';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
-import { Roles } from '../auth/roles.decorator';
+import {} from '../auth/roles.decorator';
 import { OtpService } from '../auth/otp.service';
 
 const mockUser = {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -87,7 +87,9 @@ export class UsersController {
   @ApiBearerAuth()
   @Get('me/seen-features')
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Obtener los features vistos por el usuario autenticado' })
+  @ApiOperation({
+    summary: 'Obtener los features vistos por el usuario autenticado',
+  })
   @ApiResponse({ status: 200, description: 'Lista de features vistos' })
   getSeenFeatures(@Req() req) {
     return this.usersService.getSeenFeatures(req.user.id);
@@ -97,8 +99,13 @@ export class UsersController {
   @ApiBearerAuth()
   @Post('me/seen-features')
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Marcar un feature como visto por el usuario autenticado' })
-  @ApiResponse({ status: 201, description: 'Lista actualizada de features vistos' })
+  @ApiOperation({
+    summary: 'Marcar un feature como visto por el usuario autenticado',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Lista actualizada de features vistos',
+  })
   addSeenFeature(@Req() req, @Body() body: { feature: string }) {
     return this.usersService.addSeenFeature(req.user.id, body.feature);
   }
@@ -107,9 +114,15 @@ export class UsersController {
   @ApiBearerAuth()
   @Delete('me/seen-features')
   @UseGuards(JwtAuthGuard)
-  @ApiOperation({ summary: 'Resetear features vistos. Sin query param limpia todo; con ?feature=X elimina solo ese.' })
+  @ApiOperation({
+    summary:
+      'Resetear features vistos. Sin query param limpia todo; con ?feature=X elimina solo ese.',
+  })
   @ApiQuery({ name: 'feature', required: false, type: String })
-  @ApiResponse({ status: 200, description: 'Lista actualizada de features vistos' })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista actualizada de features vistos',
+  })
   removeSeenFeature(@Req() req, @Query('feature') feature?: string) {
     return this.usersService.removeSeenFeature(req.user.id, feature);
   }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -10,7 +10,6 @@ import {
   Req,
   ForbiddenException,
   NotFoundException,
-  UnauthorizedException,
   Query,
 } from '@nestjs/common';
 import {

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -6,17 +6,13 @@ import { User } from './users.entity';
 import { DeviceService } from './device.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import {
-  NotFoundException,
-  UnauthorizedException,
-  BadRequestException,
-} from '@nestjs/common';
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 describe('UsersService', () => {
   let service: UsersService;
-  let repository: Repository<User>;
-  let deviceService: DeviceService;
+  let _repository: Repository<User>;
+  let _deviceService: DeviceService;
 
   const mockUser = {
     id: 1,
@@ -59,8 +55,8 @@ describe('UsersService', () => {
     }).compile();
 
     service = module.get<UsersService>(UsersService);
-    repository = module.get<Repository<User>>(getRepositoryToken(User));
-    deviceService = module.get<DeviceService>(DeviceService);
+    _repository = module.get<Repository<User>>(getRepositoryToken(User));
+    _deviceService = module.get<DeviceService>(DeviceService);
   });
 
   afterEach(() => {

--- a/src/utils/getBlockTTL.util.spec.ts
+++ b/src/utils/getBlockTTL.util.spec.ts
@@ -7,7 +7,7 @@ jest.mock('dayjs', () => {
   const mockDayjs = jest.fn(() => ({
     hour: () => 10,
     minute: () => 0,
-    format: (format?: string) => '2025-09-15 10:00:00',
+    format: (_format?: string) => '2025-09-15 10:00:00',
     startOf: jest.fn().mockReturnThis(),
     endOf: jest.fn().mockReturnThis(),
     diff: jest.fn().mockReturnValue(10800),

--- a/src/utils/timezone.util.spec.ts
+++ b/src/utils/timezone.util.spec.ts
@@ -1,7 +1,5 @@
 import { TimezoneUtil } from './timezone.util';
 import * as dayjs from 'dayjs';
-import * as utc from 'dayjs/plugin/utc';
-import * as timezone from 'dayjs/plugin/timezone';
 
 // Mock dayjs
 jest.mock('dayjs', () => {

--- a/src/webhooks/kick-webhook.controller.spec.ts
+++ b/src/webhooks/kick-webhook.controller.spec.ts
@@ -4,7 +4,7 @@ import { StreamerLiveStatusService } from '../streamers/streamer-live-status.ser
 import { StreamersService } from '../streamers/streamers.service';
 import { RedisService } from '../redis/redis.service';
 import { Streamer } from '../streamers/streamers.entity';
-import { NotifyAndRevalidateUtil } from '../utils/notify-and-revalidate.util';
+import {} from '../utils/notify-and-revalidate.util';
 
 // Mock the NotifyAndRevalidateUtil
 jest.mock('../utils/notify-and-revalidate.util', () => ({
@@ -16,7 +16,7 @@ jest.mock('../utils/notify-and-revalidate.util', () => ({
 describe('KickWebhookController', () => {
   let controller: KickWebhookController;
   let streamerLiveStatusService: StreamerLiveStatusService;
-  let streamersService: StreamersService;
+  let _streamersService: StreamersService;
 
   const mockStreamer: Streamer = {
     id: 1,
@@ -74,7 +74,7 @@ describe('KickWebhookController', () => {
     streamerLiveStatusService = module.get<StreamerLiveStatusService>(
       StreamerLiveStatusService,
     );
-    streamersService = module.get<StreamersService>(StreamersService);
+    _streamersService = module.get<StreamersService>(StreamersService);
   });
 
   afterEach(() => {

--- a/src/webhooks/kick-webhook.controller.spec.ts
+++ b/src/webhooks/kick-webhook.controller.spec.ts
@@ -4,7 +4,6 @@ import { StreamerLiveStatusService } from '../streamers/streamer-live-status.ser
 import { StreamersService } from '../streamers/streamers.service';
 import { RedisService } from '../redis/redis.service';
 import { Streamer } from '../streamers/streamers.entity';
-import {} from '../utils/notify-and-revalidate.util';
 
 // Mock the NotifyAndRevalidateUtil
 jest.mock('../utils/notify-and-revalidate.util', () => ({

--- a/src/webhooks/kick-webhook.controller.ts
+++ b/src/webhooks/kick-webhook.controller.ts
@@ -160,7 +160,7 @@ export class KickWebhookController {
       throw new Error('Invalid signature');
     }
 
-    const payload = body;
+    const payload = body as KickWebhookPayload;
 
     // Handle both new format (data.broadcaster) and legacy format (broadcaster)
     const broadcaster = payload.data?.broadcaster || payload.broadcaster;

--- a/src/webhooks/token-refresh.controller.spec.ts
+++ b/src/webhooks/token-refresh.controller.spec.ts
@@ -4,7 +4,7 @@ import { TokenRefreshService } from './token-refresh.service';
 
 describe('TokenRefreshController', () => {
   let controller: TokenRefreshController;
-  let tokenRefreshService: TokenRefreshService;
+  let _tokenRefreshService: TokenRefreshService;
 
   const mockTokenRefreshService = {
     refreshTwitchToken: jest.fn(),
@@ -28,7 +28,7 @@ describe('TokenRefreshController', () => {
     }).compile();
 
     controller = module.get<TokenRefreshController>(TokenRefreshController);
-    tokenRefreshService = module.get<TokenRefreshService>(TokenRefreshService);
+    _tokenRefreshService = module.get<TokenRefreshService>(TokenRefreshService);
   });
 
   afterEach(() => {

--- a/src/webhooks/token-refresh.scheduler.spec.ts
+++ b/src/webhooks/token-refresh.scheduler.spec.ts
@@ -4,7 +4,7 @@ import { TokenRefreshService } from './token-refresh.service';
 
 describe('TokenRefreshScheduler', () => {
   let scheduler: TokenRefreshScheduler;
-  let tokenRefreshService: TokenRefreshService;
+  let _tokenRefreshService: TokenRefreshService;
 
   const mockTokenRefreshService = {
     checkAndRefreshTokens: jest.fn(),
@@ -22,7 +22,7 @@ describe('TokenRefreshScheduler', () => {
     }).compile();
 
     scheduler = module.get<TokenRefreshScheduler>(TokenRefreshScheduler);
-    tokenRefreshService = module.get<TokenRefreshService>(TokenRefreshService);
+    _tokenRefreshService = module.get<TokenRefreshService>(TokenRefreshService);
   });
 
   afterEach(() => {

--- a/src/webhooks/token-refresh.scheduler.ts
+++ b/src/webhooks/token-refresh.scheduler.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import { TokenRefreshService } from './token-refresh.service';
 
 @Injectable()

--- a/src/webhooks/token-refresh.service.spec.ts
+++ b/src/webhooks/token-refresh.service.spec.ts
@@ -9,8 +9,8 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('TokenRefreshService', () => {
   let service: TokenRefreshService;
-  let configService: ConfigService;
-  let redisService: RedisService;
+  let _configService: ConfigService;
+  let _redisService: RedisService;
 
   const mockConfigService = {
     get: jest.fn(),
@@ -38,8 +38,8 @@ describe('TokenRefreshService', () => {
     }).compile();
 
     service = module.get<TokenRefreshService>(TokenRefreshService);
-    configService = module.get<ConfigService>(ConfigService);
-    redisService = module.get<RedisService>(RedisService);
+    _configService = module.get<ConfigService>(ConfigService);
+    _redisService = module.get<RedisService>(RedisService);
   });
 
   afterEach(() => {

--- a/src/webhooks/twitch-webhook.controller.spec.ts
+++ b/src/webhooks/twitch-webhook.controller.spec.ts
@@ -4,7 +4,6 @@ import { StreamerLiveStatusService } from '../streamers/streamer-live-status.ser
 import { StreamersService } from '../streamers/streamers.service';
 import { RedisService } from '../redis/redis.service';
 import { Streamer } from '../streamers/streamers.entity';
-import {} from '../utils/notify-and-revalidate.util';
 
 // Mock the NotifyAndRevalidateUtil
 jest.mock('../utils/notify-and-revalidate.util', () => ({

--- a/src/webhooks/twitch-webhook.controller.spec.ts
+++ b/src/webhooks/twitch-webhook.controller.spec.ts
@@ -4,7 +4,7 @@ import { StreamerLiveStatusService } from '../streamers/streamer-live-status.ser
 import { StreamersService } from '../streamers/streamers.service';
 import { RedisService } from '../redis/redis.service';
 import { Streamer } from '../streamers/streamers.entity';
-import { NotifyAndRevalidateUtil } from '../utils/notify-and-revalidate.util';
+import {} from '../utils/notify-and-revalidate.util';
 
 // Mock the NotifyAndRevalidateUtil
 jest.mock('../utils/notify-and-revalidate.util', () => ({
@@ -16,7 +16,7 @@ jest.mock('../utils/notify-and-revalidate.util', () => ({
 describe('TwitchWebhookController', () => {
   let controller: TwitchWebhookController;
   let streamerLiveStatusService: StreamerLiveStatusService;
-  let streamersService: StreamersService;
+  let _streamersService: StreamersService;
 
   const mockStreamer: Streamer = {
     id: 1,
@@ -74,7 +74,7 @@ describe('TwitchWebhookController', () => {
     streamerLiveStatusService = module.get<StreamerLiveStatusService>(
       StreamerLiveStatusService,
     );
-    streamersService = module.get<StreamersService>(StreamersService);
+    _streamersService = module.get<StreamersService>(StreamersService);
   });
 
   afterEach(() => {

--- a/src/webhooks/webhook-subscription.service.spec.ts
+++ b/src/webhooks/webhook-subscription.service.spec.ts
@@ -10,8 +10,8 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('WebhookSubscriptionService', () => {
   let service: WebhookSubscriptionService;
-  let configService: ConfigService;
-  let redisService: RedisService;
+  let _configService: ConfigService;
+  let _redisService: RedisService;
 
   const mockConfigService = {
     get: jest.fn(),
@@ -51,8 +51,8 @@ describe('WebhookSubscriptionService', () => {
     service = module.get<WebhookSubscriptionService>(
       WebhookSubscriptionService,
     );
-    configService = module.get<ConfigService>(ConfigService);
-    redisService = module.get<RedisService>(RedisService);
+    _configService = module.get<ConfigService>(ConfigService);
+    _redisService = module.get<RedisService>(RedisService);
   });
 
   afterEach(() => {

--- a/src/webhooks/webhook-subscription.service.ts
+++ b/src/webhooks/webhook-subscription.service.ts
@@ -236,8 +236,8 @@ export class WebhookSubscriptionService {
     kickUsername: string,
     userId?: number,
   ): Promise<string | null> {
-    const clientId = this.configService.get<string>('KICK_CLIENT_ID');
-    const clientSecret = this.configService.get<string>('KICK_CLIENT_SECRET');
+    const _clientId = this.configService.get<string>('KICK_CLIENT_ID');
+    const _clientSecret = this.configService.get<string>('KICK_CLIENT_SECRET');
     // Use token refresh service to get token (checks Redis cache first, falls back to env)
     const appAccessToken = await this.tokenRefreshService.getKickAccessToken();
     const webhookBaseUrl =
@@ -577,7 +577,7 @@ export class WebhookSubscriptionService {
     // First, get the user ID if not provided
     let channelUserId = userId;
     if (!channelUserId) {
-      const clientId = this.configService.get<string>('KICK_CLIENT_ID');
+      const _clientId = this.configService.get<string>('KICK_CLIENT_ID');
       const appAccessToken =
         await this.tokenRefreshService.getKickAccessToken();
 

--- a/src/youtube/live-status-background.service.approach-b.spec.ts
+++ b/src/youtube/live-status-background.service.approach-b.spec.ts
@@ -36,7 +36,7 @@ describe('LiveStatusBackgroundService (Approach B)', () => {
   let schedulesService: SchedulesService;
   let redisService: RedisService;
   let configService: ConfigService;
-  let channelsRepository: any;
+  let _channelsRepository: any;
 
   const mockLiveStatusCache = {
     channelId: 'CHANNEL_123',
@@ -116,7 +116,7 @@ describe('LiveStatusBackgroundService (Approach B)', () => {
     schedulesService = module.get<SchedulesService>(SchedulesService);
     redisService = module.get<RedisService>(RedisService);
     configService = module.get<ConfigService>(ConfigService);
-    channelsRepository = module.get(getRepositoryToken(Channel));
+    _channelsRepository = module.get(getRepositoryToken(Channel));
   });
 
   afterEach(() => {

--- a/src/youtube/live-status-background.service.ts
+++ b/src/youtube/live-status-background.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
+import { Cron } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { YoutubeLiveService } from './youtube-live.service';

--- a/src/youtube/youtube-live.service.not-found-retry.spec.ts
+++ b/src/youtube/youtube-live.service.not-found-retry.spec.ts
@@ -1,5 +1,5 @@
 import { YoutubeLiveService } from './youtube-live.service';
-import { ConfigService } from '../config/config.service';
+import {} from '../config/config.service';
 import { SchedulesService } from '../schedules/schedules.service';
 import { RedisService } from '../redis/redis.service';
 import { SentryService } from '../sentry/sentry.service';

--- a/src/youtube/youtube-live.service.not-found-retry.spec.ts
+++ b/src/youtube/youtube-live.service.not-found-retry.spec.ts
@@ -123,9 +123,7 @@ describe('YoutubeLiveService not-found retry cadence', () => {
 
     it('keeps the long mark when nothing is on-air', async () => {
       // Program already finished — there is nothing to retry for.
-      jest
-        .spyOn(TimezoneUtil, 'currentTimeInMinutes')
-        .mockReturnValue(13 * 60);
+      jest.spyOn(TimezoneUtil, 'currentTimeInMinutes').mockReturnValue(13 * 60);
 
       await escalate();
 
@@ -170,8 +168,7 @@ describe('YoutubeLiveService not-found retry cadence', () => {
     const isUploadsOnlyRetry = (
       programName: string | null = 'Nadie Dice Nada',
       cronType: 'main' | 'back-to-back-fix' | 'manual' = 'main',
-    ) =>
-      (service as any).isUploadsOnlyRetry(HANDLE, programName, cronType);
+    ) => (service as any).isUploadsOnlyRetry(HANDLE, programName, cronType);
 
     it('skips the search on an uncounted retry', async () => {
       redisService.get.mockResolvedValue({

--- a/src/youtube/youtube-live.service.not-found-retry.spec.ts
+++ b/src/youtube/youtube-live.service.not-found-retry.spec.ts
@@ -1,5 +1,4 @@
 import { YoutubeLiveService } from './youtube-live.service';
-import {} from '../config/config.service';
 import { SchedulesService } from '../schedules/schedules.service';
 import { RedisService } from '../redis/redis.service';
 import { SentryService } from '../sentry/sentry.service';

--- a/src/youtube/youtube-live.service.spec.ts
+++ b/src/youtube/youtube-live.service.spec.ts
@@ -4,7 +4,6 @@ import { SchedulesService } from '../schedules/schedules.service';
 import { RedisService } from '../redis/redis.service';
 import { SentryService } from '../sentry/sentry.service';
 import axios from 'axios';
-import * as dayjs from 'dayjs';
 
 describe('YoutubeLiveService', () => {
   let service: YoutubeLiveService;

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -159,7 +159,8 @@ export class YoutubeLiveService {
     handle: string,
     blockTTL: number,
     context: 'cron' | 'onDemand' | 'program-start',
-  ): Promise<string | null | '__SKIPPED__'> {
+    // El sentinela '__SKIPPED__' esta cubierto por `string`
+  ): Promise<string | null> {
     // gating centralizado
     try {
       if (!(await this.configService.canFetchLive(handle))) {
@@ -1705,8 +1706,8 @@ export class YoutubeLiveService {
 
       // Schedule a follow-up check 7 minutes later for delayed starts
       setTimeout(
-        async () => {
-          await this.checkDelayedProgramStarts(startingPrograms);
+        () => {
+          void this.checkDelayedProgramStarts(startingPrograms);
         },
         7 * 60 * 1000,
       ); // 7 minutes

--- a/src/youtube/youtube-live.service.ts
+++ b/src/youtube/youtube-live.service.ts
@@ -6,7 +6,7 @@ import * as utc from 'dayjs/plugin/utc';
 import * as timezone from 'dayjs/plugin/timezone';
 import * as DateHolidays from 'date-holidays';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository } from 'typeorm';
 
 import { SchedulesService } from '../schedules/schedules.service';
 import { RedisService } from '../redis/redis.service';
@@ -28,7 +28,7 @@ import {
 import { SimilarityUtil } from '../utils/similarity.util';
 import { filterVisibleSchedules } from '../utils/scheduleVisibility.util';
 
-const HolidaysClass = (DateHolidays as any).default ?? DateHolidays;
+const _HolidaysClass = (DateHolidays as any).default ?? DateHolidays;
 
 interface AttemptTracking {
   attempts: number;
@@ -554,7 +554,7 @@ export class YoutubeLiveService {
         // Send individual PostHog events for each channel in the batch
         for (const channelId of chunk) {
           // Find the channel handle from the provided mapping
-          const handle = channelHandleMap?.get(channelId) || 'unknown';
+          const _handle = channelHandleMap?.get(channelId) || 'unknown';
 
           // Track API usage for this specific channel
           // YouTube API usage tracking removed

--- a/src/youtube/youtube.controller.ts
+++ b/src/youtube/youtube.controller.ts
@@ -1,7 +1,5 @@
 import { Controller, Sse, Post, Body, Logger } from '@nestjs/common';
-import {} from 'express';
 import { Observable } from 'rxjs';
-import {} from 'rxjs/operators';
 import { YoutubeLiveService } from './youtube-live.service';
 import { RedisService } from '../redis/redis.service';
 

--- a/src/youtube/youtube.controller.ts
+++ b/src/youtube/youtube.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Res, Sse, Post, Body, Logger } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller, Sse, Post, Body, Logger } from '@nestjs/common';
+import {} from 'express';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import {} from 'rxjs/operators';
 import { YoutubeLiveService } from './youtube-live.service';
 import { RedisService } from '../redis/redis.service';
 

--- a/src/youtube/youtube.controller.ts
+++ b/src/youtube/youtube.controller.ts
@@ -44,92 +44,94 @@ export class YoutubeController {
       }, 30000);
 
       // Set up polling for live status changes
-      const interval = setInterval(async () => {
-        try {
-          // Check for recent live notifications (last 60 seconds to give more time)
-          const sixtySecondsAgo = Date.now() - 60000;
-          const keys = await this.redisService.client.keys(
-            'live_notification:*',
-          );
+      const interval = setInterval(() => {
+        void (async () => {
+          try {
+            // Check for recent live notifications (last 60 seconds to give more time)
+            const sixtySecondsAgo = Date.now() - 60000;
+            const keys = await this.redisService.client.keys(
+              'live_notification:*',
+            );
 
-          if (keys.length > 0) {
-            const keysToFetch: string[] = [];
-            const keysToDelete: string[] = [];
+            if (keys.length > 0) {
+              const keysToFetch: string[] = [];
+              const keysToDelete: string[] = [];
 
-            // First pass: classify keys by timestamp
-            for (const key of keys) {
-              const parts = key.split(':');
-              const timestamp = parseInt(parts[parts.length - 1]);
+              // First pass: classify keys by timestamp
+              for (const key of keys) {
+                const parts = key.split(':');
+                const timestamp = parseInt(parts[parts.length - 1]);
 
-              if (isNaN(timestamp)) {
-                this.logger.warn(
-                  `Invalid timestamp in notification key: ${key}`,
+                if (isNaN(timestamp)) {
+                  this.logger.warn(
+                    `Invalid timestamp in notification key: ${key}`,
+                  );
+                  continue;
+                }
+
+                if (timestamp > sixtySecondsAgo) {
+                  keysToFetch.push(key);
+                } else {
+                  keysToDelete.push(key);
+                }
+              }
+
+              // Batch fetch recent notifications in a single mget
+              if (keysToFetch.length > 0) {
+                const notificationStrings = await this.redisService.client.mget(
+                  ...keysToFetch,
                 );
-                continue;
-              }
 
-              if (timestamp > sixtySecondsAgo) {
-                keysToFetch.push(key);
-              } else {
-                keysToDelete.push(key);
-              }
-            }
+                for (const notificationString of notificationStrings) {
+                  if (
+                    notificationString &&
+                    typeof notificationString === 'string'
+                  ) {
+                    try {
+                      const notification = JSON.parse(
+                        notificationString,
+                      ) as LiveNotification;
 
-            // Batch fetch recent notifications in a single mget
-            if (keysToFetch.length > 0) {
-              const notificationStrings = await this.redisService.client.mget(
-                ...keysToFetch,
-              );
+                      // Create a unique identifier for this notification
+                      const notificationId = notification.channelId
+                        ? `${notification.type}:${notification.channelId}:${notification.timestamp}`
+                        : `${notification.type}:${notification.entity}:${notification.entityId}:${notification.timestamp}`;
 
-              for (const notificationString of notificationStrings) {
-                if (
-                  notificationString &&
-                  typeof notificationString === 'string'
-                ) {
-                  try {
-                    const notification = JSON.parse(
-                      notificationString,
-                    ) as LiveNotification;
+                      // Only send if we haven't sent this notification before (per-connection)
+                      if (!this.sentNotifications.has(notificationId)) {
+                        this.sentNotifications.add(notificationId);
 
-                    // Create a unique identifier for this notification
-                    const notificationId = notification.channelId
-                      ? `${notification.type}:${notification.channelId}:${notification.timestamp}`
-                      : `${notification.type}:${notification.entity}:${notification.entityId}:${notification.timestamp}`;
+                        subscriber.next({
+                          data: JSON.stringify(notification),
+                          type: 'message',
+                        } as MessageEvent);
 
-                    // Only send if we haven't sent this notification before (per-connection)
-                    if (!this.sentNotifications.has(notificationId)) {
-                      this.sentNotifications.add(notificationId);
+                        // IMPORTANT: Do NOT delete the Redis key here.
+                        // We want ALL connected clients to receive the notification.
+                        // Each connection tracks what it has already sent via sentNotifications.
+                        // Old notifications are cleaned up below (timestamp check) or by TTL.
 
-                      subscriber.next({
-                        data: JSON.stringify(notification),
-                        type: 'message',
-                      } as MessageEvent);
-
-                      // IMPORTANT: Do NOT delete the Redis key here.
-                      // We want ALL connected clients to receive the notification.
-                      // Each connection tracks what it has already sent via sentNotifications.
-                      // Old notifications are cleaned up below (timestamp check) or by TTL.
-
-                      // Clean up the tracking set after 1 minute to prevent memory leaks
-                      setTimeout(() => {
-                        this.sentNotifications.delete(notificationId);
-                      }, 60000);
+                        // Clean up the tracking set after 1 minute to prevent memory leaks
+                        setTimeout(() => {
+                          this.sentNotifications.delete(notificationId);
+                        }, 60000);
+                      }
+                    } catch (error) {
+                      this.logger.error('Error parsing notification:', error);
                     }
-                  } catch (error) {
-                    this.logger.error('Error parsing notification:', error);
                   }
                 }
               }
-            }
 
-            // Batch delete expired notifications in a single DEL
-            if (keysToDelete.length > 0) {
-              await this.redisService.del(keysToDelete);
+              // Batch delete expired notifications in a single DEL
+              if (keysToDelete.length > 0) {
+                await this.redisService.del(keysToDelete);
+              }
             }
+          } catch (error) {
+            this.logger.error('Error in live events SSE polling:', error);
           }
-        } catch (error) {
-          this.logger.error('Error in live events SSE polling:', error);
-        }
+        })();
       }, 2000); // Check every 2 seconds
 
       // Cleanup on disconnect

--- a/test/bulk-youtube-fetch-test.ts
+++ b/test/bulk-youtube-fetch-test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const API_URL = 'http://localhost:3000'; // Local environment for testing
-const LOCAL_API_URL = 'http://localhost:3000';
+const _LOCAL_API_URL = 'http://localhost:3000';
 
 interface PerformanceResult {
   endpoint: string;


### PR DESCRIPTION
Consolida los 12 PRs abiertos de Jules y deja el linter en cero.

## Parte 1 — PRs de Jules

Los 12 PRs abiertos eran en realidad **3 cambios distintos, repetidos**: el mismo N+1 de `ProgramsService.createBulk` fue "descubierto" y re-parcheado 10 veces en días consecutivos. Se incorporan los 2 reales y se descarta el ruido.

| Cambio | PRs | Estado |
|---|---|---|
| N+1 en `ProgramsService.createBulk` (panelistas → `In()`) | #395 #391 #390 #389 #388 #387 #386 #385 #383 #382 | ✅ Incorporado una vez |
| `canFetchLiveBulk` en Config + `PushScheduler` | #393 #384 | ✅ Incorporado (variante propia) |
| Reformateo de `src/migrations/*` a líneas largas | #393 #385 #383 | ❌ Descartado: revierte prettier |
| Bump `typescript` ^5.7.3 → ^5.8.3 | #387 | ❌ Descartado: no relacionado |

**Sobre `canFetchLiveBulk`**: no se usó ninguna de las dos versiones de Jules. Ambas alteraban la precedencia de fallback ante cache miss — la de #393 además asume que `ensureCacheSeeded()` garantiza que la llave esté en cache, lo cual no es cierto, y devolvía `true` por defecto. La versión de este PR batchea con `mget` el camino cacheado (el 99% de los casos) y **delega en `canFetchLive(handle)` ante cualquier miss**, así la precedencia (por canal → global → DB) y el calentamiento del cache quedan idénticos. Cubierto con 6 tests nuevos.

## Parte 2 — Linter: 3082 → 0

`npm run lint` levantaba 2728 errores + 354 warnings. Se resolvió en capas, con la suite corriendo en cada una:

1. **Formato** — 17 fixes automáticos de prettier.
2. **Bugs reales** (~25) — promesas flotantes, callbacks `async` pasados a `setTimeout`/`setInterval`/`setImmediate`, `case` con `const` sin bloque, tipos redundantes, el `await` faltante en `ConfigService.set`.
3. **Código muerto** — 60 imports eliminados; 84 variables y parámetros sin usar marcados con prefijo `_` en vez de borrarse, para no eliminar por accidente ninguna expresión con efecto colateral.
4. **Configuración** — se apagan, con el razonamiento comentado en `eslint.config.mjs`, la familia `no-unsafe-*` (2519 hallazgos, 82% del total), `require-await`, `no-require-imports` y `unbound-method` (solo en specs).

Se **mantienen en `error`** las reglas que atrapan bugs reales: `no-floating-promises`, `no-misused-promises` y `no-unused-vars`.

### Por qué por configuración y no retipando

El proyecto ya tenía `no-explicit-any: off`, o sea que acepta `any` deliberadamente (respuestas de APIs externas, payloads de webhooks, filas crudas de TypeORM). Pero `recommendedTypeChecked` marca cada *uso* de esos `any`, y eliminarlos de verdad implica escribir tipos reales en los 71 archivos de `src/` — semanas de trabajo con alto riesgo sobre código productivo. Apagar `no-unsafe-*` es coherente con la decisión que el proyecto ya había tomado.

`require-await`, `no-require-imports` y `unbound-method` se revisaron caso por caso: los 16 `require-await` productivos son `async` como contrato de interfaz (wrappers de jsonwebtoken, hooks de Passport/NestJS, factories) y quitarles el `async` convertiría rechazos en throws sincrónicos; los `require()` son lazy imports deliberados (cortar la dependencia circular `weekly-overrides` → `schedules`, cargar la service-account de Firebase por path); los 271 `unbound-method` están todos en specs, donde `expect(repo.findOne)` es el uso idiomático de jest.

## CI y documentación

- Nuevo script `lint:ci` (`eslint` sin `--fix`, `--max-warnings=0`).
- Nuevo job `lint` en `.github/workflows/ci-test.yml`, que corre en cada PR a `main`/`develop`.
- Sección **"Linting (OBLIGATORIO)"** en `CLAUDE.md` con la regla de que todo desarrollo nuevo debe pasar el linter, cómo arreglar sin ensuciar el commit y por qué no se silencia un hallazgo con `eslint-disable`.

## Verificación

| Check | Resultado |
|---|---|
| `npm run lint:ci` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `npm run build` | exit 0 |
| `npm test` | **757 passing**, 1 skipped, 70 suites |

El baseline de `develop` era 751 passing; los 6 de diferencia son los tests nuevos de `canFetchLiveBulk`.

## Para revisar con atención

1. **Único cambio de comportamiento deliberado**: `ConfigService.set()` ahora espera a `notifyAndRevalidate`. Era el único call site del repo sin `await`. Afecta al endpoint de configuración del backoffice, que ahora responde después de que termine la revalidación. Si se prefiere conservar el fire-and-forget, se cambia por `void`.
2. **Hallazgo latente, sin tocar**: `SchedulesService` acepta las opciones `applyOverrides` y `liveStatus` (con defaults) y el parámetro `relations` de `fetchSchedulesFromDatabase`, pero nunca las lee. Quedaron marcadas con `_` sin modificar la lógica. Puede ser deuda inofensiva o una feature ignorada en silencio; vale revisarlo aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmT9MtdXhUi1R1kdrUMrnj
