### PR TITLE
⚡ Bolt: Optimize N+1 saves in programs service panelist methods

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-08-18 - [Un PR por hallazgo, no uno por dia]
 **Learning:** Se acumularon 12 PRs abiertos que en realidad eran 3 cambios distintos: el mismo N+1 de `ProgramsService.createBulk` fue "descubierto" y re-parcheado 10 veces en dias consecutivos.
 **Action:** Antes de abrir un PR, revisar los PRs abiertos existentes. Si el hallazgo ya tiene un PR, no abrir otro. Ademas: nunca reformatear archivos no relacionados (varios PRs des-formateaban `src/migrations/*` a lineas largas, rompiendo prettier).
+
+## 2024-05-30 - [Optimize N+1 saves in programs service panelist methods]
+**Learning:** In `ProgramsService.addPanelist` and `ProgramsService.removePanelist`, updating linked programs inside a `for...of` loop caused N+1 sequential database `save()` calls and Redis `del()` calls, leading to slow performance when updating multiple related programs.
+**Action:** When applying identical mutations to multiple entities derived from a loop (like linked programs), accumulate the entities in an array (`othersToUpdate`) and use a single batched `save(othersToUpdate)`. Likewise, aggregate cache keys into an array (`cacheKeysToDel`) and use `RedisService.del(keysArray)` to process invalidations in one network round-trip.

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -422,13 +422,21 @@ export class ProgramsService {
         relations: ['panelists'],
       });
       const others = linked.filter((p) => p.id !== programId);
+      const othersToUpdate: Program[] = [];
+      const cacheKeysToDel: string[] = [];
+
       for (const other of others) {
         if (!other.panelists) other.panelists = [];
         if (!other.panelists.some((p) => p.id === panelistId)) {
           other.panelists.push(panelist);
-          await this.programsRepository.save(other);
-          await this.redisService.del([`programs:${other.id}`]);
+          othersToUpdate.push(other);
+          cacheKeysToDel.push(`programs:${other.id}`);
         }
+      }
+
+      if (othersToUpdate.length > 0) {
+        await this.programsRepository.save(othersToUpdate);
+        await this.redisService.del(cacheKeysToDel);
       }
     }
 
@@ -467,12 +475,23 @@ export class ProgramsService {
         relations: ['panelists'],
       });
       const others = linked.filter((p) => p.id !== programId);
+      const othersToUpdate: Program[] = [];
+      const cacheKeysToDel: string[] = [];
+
       for (const other of others) {
         if (other.panelists) {
+          const originalLength = other.panelists.length;
           other.panelists = other.panelists.filter((p) => p.id !== panelistId);
-          await this.programsRepository.save(other);
-          await this.redisService.del([`programs:${other.id}`]);
+          if (other.panelists.length !== originalLength) {
+            othersToUpdate.push(other);
+            cacheKeysToDel.push(`programs:${other.id}`);
+          }
         }
+      }
+
+      if (othersToUpdate.length > 0) {
+        await this.programsRepository.save(othersToUpdate);
+        await this.redisService.del(cacheKeysToDel);
       }
     }
 


### PR DESCRIPTION
💡 **What**: Refactored the `addPanelist` and `removePanelist` methods in `src/programs/programs.service.ts` to batch database saves and Redis cache invalidations when propagating changes to linked programs.
🎯 **Why**: Previously, the service iterated over linked programs sequentially, calling `await this.programsRepository.save(other)` and `await this.redisService.del(...)` individually for each related program. This caused an N+1 query overhead and multiple network round-trips to Redis.
📊 **Impact**: Reduces database write transactions and Redis round-trips from O(N) to O(1) for linked programs updates.
🔬 **Measurement**: The improvement can be verified by observing database and Redis query logs when adding or removing a panelist on a program that is part of a large link group.

Additionally, in `removePanelist`, a check was added to verify if the panelist list actually changed (`length` comparison) before scheduling the entity for update.

---
*PR created automatically by Jules for task [7416439252967154772](https://jules.google.com/task/7416439252967154772) started by @matiasrozenblum*