### PR TITLE
⚡ Bolt: Fix N+1 DB and Redis queries during program panelist updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2026-08-18 - [Un PR por hallazgo, no uno por dia]
 **Learning:** Se acumularon 12 PRs abiertos que en realidad eran 3 cambios distintos: el mismo N+1 de `ProgramsService.createBulk` fue "descubierto" y re-parcheado 10 veces en dias consecutivos.
 **Action:** Antes de abrir un PR, revisar los PRs abiertos existentes. Si el hallazgo ya tiene un PR, no abrir otro. Ademas: nunca reformatear archivos no relacionados (varios PRs des-formateaban `src/migrations/*` a lineas largas, rompiendo prettier).
+
+## 2026-09-02 - [N+1 Query Avoidance in Program Panelists Updates]
+**Learning:** Found N+1 query patterns inside `addPanelist` and `removePanelist` of `ProgramsService`. They were iterating over linked programs and executing `await this.programsRepository.save(other)` and `await this.redisService.del(...)` individually inside a loop.
+**Action:** Accumulate entities into a typed array (`const othersToUpdate: Program[] = []`) and perform a single batched `.save()` and `.del()` outside the loop.

--- a/src/programs/programs.service.ts
+++ b/src/programs/programs.service.ts
@@ -422,13 +422,21 @@ export class ProgramsService {
         relations: ['panelists'],
       });
       const others = linked.filter((p) => p.id !== programId);
+      const othersToUpdate: Program[] = [];
       for (const other of others) {
         if (!other.panelists) other.panelists = [];
         if (!other.panelists.some((p) => p.id === panelistId)) {
           other.panelists.push(panelist);
-          await this.programsRepository.save(other);
-          await this.redisService.del([`programs:${other.id}`]);
+          othersToUpdate.push(other);
         }
+      }
+
+      if (othersToUpdate.length > 0) {
+        // Optimize: Batch save and cache clear to eliminate N+1 overhead
+        await this.programsRepository.save(othersToUpdate);
+        await this.redisService.del(
+          othersToUpdate.map((p) => `programs:${p.id}`),
+        );
       }
     }
 
@@ -467,12 +475,23 @@ export class ProgramsService {
         relations: ['panelists'],
       });
       const others = linked.filter((p) => p.id !== programId);
+      const othersToUpdate: Program[] = [];
       for (const other of others) {
         if (other.panelists) {
+          const initialLength = other.panelists.length;
           other.panelists = other.panelists.filter((p) => p.id !== panelistId);
-          await this.programsRepository.save(other);
-          await this.redisService.del([`programs:${other.id}`]);
+          if (other.panelists.length !== initialLength) {
+            othersToUpdate.push(other);
+          }
         }
+      }
+
+      if (othersToUpdate.length > 0) {
+        // Optimize: Batch save and cache clear to eliminate N+1 overhead
+        await this.programsRepository.save(othersToUpdate);
+        await this.redisService.del(
+          othersToUpdate.map((p) => `programs:${p.id}`),
+        );
       }
     }
 


### PR DESCRIPTION
💡 **What:** Refactored `addPanelist` and `removePanelist` methods in `ProgramsService` to batch database saves and Redis cache invalidations when propagating panelist changes to linked programs.
🎯 **Why:** To eliminate an N+1 query pattern where the system executed one `save()` and one `del()` command per linked program inside a `for...of` loop, which caused high latency and database/Redis network bottlenecks when many programs were linked together.
📊 **Impact:** Reduces database writes and Redis network calls from O(N) to O(1) for linked program propagation. Includes an early-bail check during removal so unchanged entities are omitted entirely.
🔬 **Measurement:** Code verified via unit tests (`ProgramsService` suite passed successfully, verifying entity structures). Wait time drops as propagation scales up.

---
*PR created automatically by Jules for task [16807717963228823763](https://jules.google.com/task/16807717963228823763) started by @matiasrozenblum*